### PR TITLE
fix: enable BackHandler for album selection in LibraryScreen

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -522,7 +522,7 @@ fun LibraryScreen(
     var showMultiSelectionSheet by remember { mutableStateOf(false) }
     var selectedAlbums by remember { mutableStateOf<List<Album>>(emptyList()) }
     val selectedAlbumIds = remember(selectedAlbums) { selectedAlbums.map { it.id }.toSet() }
-    val isAlbumSelectionMode = selectedAlbums.isNotEmpty()
+    val isAlbumSelectionMode by remember { derivedStateOf { selectedAlbums.isNotEmpty() } }
     var showAlbumMultiSelectionSheet by remember { mutableStateOf(false) }
     var showBatchEditSheet by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
• Changed isAlbumSelectionMode to use derivedStateOf to ensure it is correctly tracked as a Compose state.

• This allows hasSelectionInCurrentTab to react to album selection changes, properly enabling the BackHandler.

• Fixed a bug where pressing the system back button while in album selection mode would close the app instead of clearing the selection.