### PR TITLE
feat(wear): Wear OS companion app — playlist transfer, local playback & remote control

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -302,6 +302,10 @@
                     android:scheme="wear"
                     android:host="*"
                     android:pathPrefix="/watch_library_state" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/playlist_sync_ack" />
             </intent-filter>
         </service>
 

--- a/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
@@ -16,6 +16,7 @@ import coil.ImageLoaderFactory
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 import com.theveloper.pixelplay.data.diagnostics.AdvancedPerformanceDiagnosticsController
 import com.theveloper.pixelplay.data.repository.ArtistImageRepository
+import com.theveloper.pixelplay.data.service.wear.PlaylistWatchTransferCoordinator
 import com.theveloper.pixelplay.data.telegram.TelegramRepository
 import com.theveloper.pixelplay.presentation.viewmodel.LibraryStateHolder
 import com.theveloper.pixelplay.presentation.viewmodel.ThemeStateHolder
@@ -71,6 +72,12 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
 
     @Inject
     lateinit var advancedPerformanceDiagnosticsController: dagger.Lazy<AdvancedPerformanceDiagnosticsController>
+
+    @Inject
+    lateinit var playlistWatchTransferCoordinator: dagger.Lazy<PlaylistWatchTransferCoordinator>
+
+    @Inject
+    lateinit var wearPhoneTransferSender: dagger.Lazy<com.theveloper.pixelplay.data.service.wear.WearPhoneTransferSender>
 
     private val startupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -128,6 +135,34 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
             }.getOrNull()
             if (savedLimit != null) {
                 AlbumArtCacheManager.configuredCacheLimitMb = savedLimit.toLong()
+            }
+        }
+
+        startupScope.launch {
+            // Best-effort: a cold start not directly triggered by the user (e.g. the system
+            // reviving the process for an unrelated broadcast) may be too restricted to start the
+            // foreground service this resumes into — resumePersistedBatchIfNeeded() just skips
+            // resuming this time rather than crashing app startup over it; the persisted intent
+            // stays put for the next launch that can.
+            try {
+                playlistWatchTransferCoordinator.get().resumePersistedBatchIfNeeded()
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to resume an interrupted playlist watch transfer")
+            }
+        }
+
+        startupScope.launch {
+            // Local Play Services call, not a network wait — resolved well before the user could
+            // navigate to a screen that needs it. Best-effort: watch-related UI just stays hidden
+            // this session if this fails, rather than crashing startup over it.
+            try {
+                wearPhoneTransferSender.get().refreshWatchPairingState()
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to check watch pairing state at startup")
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -219,6 +219,11 @@ class UserPreferencesRepository @Inject constructor(
             longPreferencesKey("advanced_performance_diagnostics_started_at_epoch_ms")
         val ADVANCED_PERFORMANCE_DIAGNOSTICS_EXPIRES_AT =
             longPreferencesKey("advanced_performance_diagnostics_expires_at_epoch_ms")
+        // Wear OS performance toggles (synced to the watch via WearPerformanceSettingsPublisher)
+        val WEAR_SHOW_ALBUM_ART = booleanPreferencesKey("wear_show_album_art")
+        val WEAR_DYNAMIC_COLOR_THEMING = booleanPreferencesKey("wear_dynamic_color_theming")
+        val WEAR_PLAY_BUTTON_ANIMATION = booleanPreferencesKey("wear_play_button_animation")
+
         val IMMERSIVE_LYRICS_ENABLED = booleanPreferencesKey("immersive_lyrics_enabled")
         val IMMERSIVE_LYRICS_TIMEOUT = longPreferencesKey("immersive_lyrics_timeout")
         val USE_ANIMATED_LYRICS = booleanPreferencesKey("use_animated_lyrics")
@@ -1242,6 +1247,32 @@ suspend fun markDirectoryRulesVersionApplied(version: Int) {
 
     suspend fun setHapticsEnabled(enabled: Boolean) {
         dataStore.edit { it[PreferencesKeys.HAPTICS_ENABLED] = enabled }
+    }
+
+    // ─── Wear OS performance toggles ────────────────────────────────────────────
+    // Only take effect during standalone local playback on the watch (no phone connected) —
+    // remote-controller mode never decodes anything heavy on the watch, so there's nothing to
+    // save there. All three default to true, preserving today's behavior.
+
+    val wearShowAlbumArtFlow: Flow<Boolean> =
+        pref { it[PreferencesKeys.WEAR_SHOW_ALBUM_ART] ?: true }
+
+    suspend fun setWearShowAlbumArt(enabled: Boolean) {
+        dataStore.edit { it[PreferencesKeys.WEAR_SHOW_ALBUM_ART] = enabled }
+    }
+
+    val wearDynamicColorThemingFlow: Flow<Boolean> =
+        pref { it[PreferencesKeys.WEAR_DYNAMIC_COLOR_THEMING] ?: true }
+
+    suspend fun setWearDynamicColorTheming(enabled: Boolean) {
+        dataStore.edit { it[PreferencesKeys.WEAR_DYNAMIC_COLOR_THEMING] = enabled }
+    }
+
+    val wearPlayButtonAnimationFlow: Flow<Boolean> =
+        pref { it[PreferencesKeys.WEAR_PLAY_BUTTON_ANIMATION] ?: true }
+
+    suspend fun setWearPlayButtonAnimation(enabled: Boolean) {
+        dataStore.edit { it[PreferencesKeys.WEAR_PLAY_BUTTON_ANIMATION] = enabled }
     }
 
     // ─── Backup / restore ─────────────────────────────────────────────────────

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
@@ -43,9 +43,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
@@ -91,6 +93,18 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         }
     }
 
+    /**
+     * Substitutes the audio actually streamed to the watch with an already-transcoded file (see
+     * [WatchAudioTranscoder]), bypassing [isSongTransferEligible] and the song's own local-file
+     * resolution — the override file was just written locally by the transcoder, so it's
+     * unconditionally eligible regardless of what the original [Song]'s source was.
+     */
+    data class WatchAudioOverride(
+        val file: File,
+        val mimeType: String,
+        val bitrateBps: Int,
+    )
+
     fun startTransferToWatch(
         nodeId: String,
         requestId: String,
@@ -98,6 +112,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         transferMode: String = WearTransferRequest.MODE_SAVE_TO_LIBRARY,
         startPositionMs: Long = 0L,
         autoPlay: Boolean = false,
+        audioOverride: WatchAudioOverride? = null,
     ) {
         transferStateStore.markRequested(
             requestId = requestId,
@@ -112,6 +127,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 transferMode = transferMode,
                 startPositionMs = startPositionMs,
                 autoPlay = autoPlay,
+                audioOverride = audioOverride,
             )
         }
     }
@@ -123,6 +139,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         transferMode: String,
         startPositionMs: Long,
         autoPlay: Boolean,
+        audioOverride: WatchAudioOverride? = null,
     ) {
         var openedSongSource: OpenedSongSource? = null
         try {
@@ -138,6 +155,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
             }
 
             if (
+                audioOverride == null &&
                 transferMode == WearTransferRequest.MODE_SAVE_TO_LIBRARY &&
                 !isSongTransferEligible(song)
             ) {
@@ -150,19 +168,23 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 return
             }
 
-            val songSource = openSongSource(
-                song = song,
-                allowProxyStreaming = transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK,
-            )
+            val songSource = if (audioOverride != null) {
+                openOverrideSongSource(audioOverride)
+            } else {
+                openSongSource(
+                    song = song,
+                    allowProxyStreaming = transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK,
+                )
+            }
             if (songSource == null) {
                 sendTransferMetadataError(
                     nodeId = nodeId,
                     requestId = requestId,
                     songId = song.id,
-                    errorMessage = if (transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK) {
-                        "Cannot stream audio source to watch"
-                    } else {
-                        "Cannot read audio file"
+                    errorMessage = when {
+                        audioOverride != null -> "Cannot read transcoded audio file"
+                        transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK -> "Cannot stream audio source to watch"
+                        else -> "Cannot read audio file"
                     },
                 )
                 return
@@ -182,9 +204,9 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 album = song.album,
                 albumId = song.albumId,
                 duration = song.duration,
-                mimeType = song.mimeType ?: "audio/mpeg",
+                mimeType = audioOverride?.mimeType ?: (song.mimeType ?: "audio/mpeg"),
                 fileSize = fileSize,
-                bitrate = song.bitrate ?: 0,
+                bitrate = audioOverride?.bitrateBps ?: (song.bitrate ?: 0),
                 sampleRate = song.sampleRate ?: 0,
                 isFavorite = song.isFavorite,
                 paletteSeedArgb = paletteSeedArgb,
@@ -211,19 +233,12 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 return
             }
 
-            messageClient.sendMessage(
-                nodeId,
-                WearDataPaths.TRANSFER_METADATA,
-                json.encodeToString(metadata).toByteArray(Charsets.UTF_8),
-            ).await()
-
-            // Give the watch a brief window to reject duplicates before the audio stream starts.
-            delay(METADATA_GUARD_DELAY_MS)
-            val duplicateRejected = transferStateStore.transfers.value[requestId]?.let { transfer ->
-                transfer.status == WearTransferProgress.STATUS_FAILED &&
-                    transfer.error == WearTransferProgress.ERROR_ALREADY_ON_WATCH
-            } == true
-            if (duplicateRejected) {
+            val metadataOutcome = sendMetadataAndAwaitAck(
+                nodeId = nodeId,
+                requestId = requestId,
+                metadataBytes = json.encodeToString(metadata).toByteArray(Charsets.UTF_8),
+            )
+            if (metadataOutcome == MetadataAckOutcome.DUPLICATE_REJECTED) {
                 runCatching { openedSongSource.close() }
                 openedSongSource = null
                 return
@@ -262,6 +277,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 songId = song.id,
                 inputStream = songSource.inputStream,
                 fileSize = fileSize,
+                transferMode = transferMode,
             )
             runCatching { songSource.close() }
             openedSongSource = null
@@ -323,6 +339,15 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
 
         val streamUrl = resolveStreamUrl(song) ?: return null
         return openHttpSongSource(streamUrl)
+    }
+
+    private fun openOverrideSongSource(override: WatchAudioOverride): OpenedSongSource? {
+        val file = override.file.takeIf { it.isFile && it.canRead() && it.length() > 0L } ?: return null
+        return runCatching {
+            OpenedSongSource(inputStream = file.inputStream(), fileSize = file.length())
+        }.onFailure { error ->
+            Timber.tag(TAG).w(error, "Failed to open transcoded override file=%s", file.absolutePath)
+        }.getOrNull()
     }
 
     private fun openDirectSongSource(song: Song): OpenedSongSource? {
@@ -739,6 +764,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         songId: String,
         inputStream: InputStream,
         fileSize: Long,
+        transferMode: String,
     ) {
         if (transferCancellationStore.consumeCancellation(requestId)) {
             sendTransferProgress(
@@ -811,14 +837,34 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
 
             shouldForceCloseChannel = false
 
-            sendTransferProgress(
-                nodeId = nodeId,
-                requestId = requestId,
-                songId = songId,
-                bytesTransferred = fileSize,
-                totalBytes = fileSize,
-                status = WearTransferProgress.STATUS_COMPLETED,
-            )
+            if (transferMode == WearTransferRequest.MODE_SAVE_TO_LIBRARY) {
+                // Bytes are on the wire, but that's not the same as "the watch has it" — wait
+                // for the watch's own write-complete/failure report (WearCommandReceiver's
+                // TRANSFER_PROGRESS handler, fed by WearTransferRepository) before this counts
+                // as done. STATUS_AWAITING_WATCH_ACK is local-only, never sent to the watch — the
+                // outer await in PlaylistWatchTransferCoordinator.transferSongToNode just keeps
+                // waiting past it (it isn't a terminal status) until the real outcome lands, with
+                // its own timeout as the backstop if that never happens.
+                transferStateStore.markProgress(
+                    requestId = requestId,
+                    songId = songId,
+                    bytesTransferred = fileSize,
+                    totalBytes = fileSize,
+                    status = WearTransferProgress.STATUS_AWAITING_WATCH_ACK,
+                )
+            } else {
+                // Temporary playback isn't part of the "is this saved on watch" bookkeeping and
+                // is latency-sensitive (the watch is waiting to start playing), so it keeps the
+                // original optimistic-completion behavior.
+                sendTransferProgress(
+                    nodeId = nodeId,
+                    requestId = requestId,
+                    songId = songId,
+                    bytesTransferred = fileSize,
+                    totalBytes = fileSize,
+                    status = WearTransferProgress.STATUS_COMPLETED,
+                )
+            }
         } catch (error: Exception) {
             Timber.tag(TAG).e(error, "Failed to stream file to watch")
             sendTransferProgress(
@@ -911,6 +957,58 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         )
     }
 
+    private enum class MetadataAckOutcome { ACKED, DUPLICATE_REJECTED, TIMED_OUT }
+
+    /**
+     * Sends [metadataBytes] and waits for the watch to either ack receipt
+     * ([WearTransferProgress.STATUS_METADATA_RECEIVED]) or reject it as a duplicate — instead of
+     * the old fixed blind delay, which let the audio channel open (and the watch start draining
+     * it) before confirming the metadata message even arrived. Real hardware testing showed that
+     * race losing under Bluetooth contention (a connected headset, the watch's screen toggling on
+     * a run) and the watch failing with "Transfer metadata missing" after already receiving the
+     * whole file. Retries the send once on timeout, same shape as
+     * [PlaylistWatchTransferCoordinator.sendPlaylistSyncToNodeWithRetry] — if the retry also times
+     * out, streams anyway rather than blocking a whole song indefinitely; the completion-ack work
+     * in [streamFileToWatch] still catches a genuine failure downstream.
+     */
+    private suspend fun sendMetadataAndAwaitAck(
+        nodeId: String,
+        requestId: String,
+        metadataBytes: ByteArray,
+    ): MetadataAckOutcome {
+        messageClient.sendMessage(nodeId, WearDataPaths.TRANSFER_METADATA, metadataBytes).await()
+        val outcome = awaitMetadataAck(requestId)
+        if (outcome != MetadataAckOutcome.TIMED_OUT) return outcome
+
+        Timber.tag(TAG).w("No metadata ack from watch, retrying once: requestId=%s", requestId)
+        messageClient.sendMessage(nodeId, WearDataPaths.TRANSFER_METADATA, metadataBytes).await()
+        val retryOutcome = awaitMetadataAck(requestId)
+        if (retryOutcome == MetadataAckOutcome.TIMED_OUT) {
+            Timber.tag(TAG).w(
+                "Metadata ack still missing after retry, streaming anyway: requestId=%s",
+                requestId,
+            )
+        }
+        return retryOutcome
+    }
+
+    private suspend fun awaitMetadataAck(requestId: String): MetadataAckOutcome {
+        val transfer = withTimeoutOrNull(METADATA_ACK_TIMEOUT_MS) {
+            transferStateStore.transfers
+                .mapNotNull { it[requestId] }
+                .first { transfer ->
+                    transfer.status == WearTransferProgress.STATUS_METADATA_RECEIVED ||
+                        (transfer.status == WearTransferProgress.STATUS_FAILED &&
+                            transfer.error == WearTransferProgress.ERROR_ALREADY_ON_WATCH)
+                }
+        }
+        return when {
+            transfer == null -> MetadataAckOutcome.TIMED_OUT
+            transfer.status == WearTransferProgress.STATUS_FAILED -> MetadataAckOutcome.DUPLICATE_REJECTED
+            else -> MetadataAckOutcome.ACKED
+        }
+    }
+
     private suspend fun sendTransferProgress(
         nodeId: String,
         requestId: String,
@@ -960,6 +1058,10 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         const val TRANSFER_ARTWORK_MAX_DIMENSION = 1024
         const val TRANSFER_ARTWORK_QUALITY = 95
         const val TRANSFER_ARTWORK_MAX_BYTES = 1_500_000
-        const val METADATA_GUARD_DELAY_MS = 250L
+        // Real round-trip over the watch's Wear Data Layer connection, not a local guard delay
+        // (the old blind 250ms) — generous enough for Bluetooth contention with a connected
+        // headset, short enough that a genuinely unreachable watch fails a song quickly instead
+        // of dragging out a whole playlist.
+        const val METADATA_ACK_TIMEOUT_MS = 4_000L
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStore.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStore.kt
@@ -76,6 +76,9 @@ class PhoneWatchTransferStateStore @Inject constructor() {
     private val watchSongIdsByNodeId = ConcurrentHashMap<String, Set<String>>()
     private val _watchSongIds = MutableStateFlow<Set<String>>(emptySet())
     val watchSongIds: StateFlow<Set<String>> = _watchSongIds.asStateFlow()
+    private val watchPlaylistIdsByNodeId = ConcurrentHashMap<String, Set<String>>()
+    private val _watchPlaylistIds = MutableStateFlow<Set<String>>(emptySet())
+    val watchPlaylistIds: StateFlow<Set<String>> = _watchPlaylistIds.asStateFlow()
 
     // Distinct from reachableWatchNodeIds: "ever paired" (CapabilityClient FILTER_ALL) vs
     // "reachable right now" (FILTER_REACHABLE). Defaults to false — safer to hide watch-related
@@ -250,6 +253,18 @@ class PhoneWatchTransferStateStore @Inject constructor() {
         watchAckTimeoutJobs.remove(requestId)?.cancel()
     }
 
+    /**
+     * Replaces this phone's picture of [nodeId]'s contents with what that watch just reported —
+     * authoritative, so songs (or whole playlists) that are gone from the watch stop counting as
+     * present here.
+     */
+    fun updateWatchLibrary(nodeId: String, songIds: Set<String>, playlistIds: Set<String>) {
+        if (nodeId.isBlank()) return
+        watchPlaylistIdsByNodeId[nodeId] = playlistIds
+        _watchPlaylistIds.value = watchPlaylistIdsByNodeId.values.flatten().toSet()
+        updateWatchSongIds(nodeId, songIds)
+    }
+
     fun updateWatchSongIds(nodeId: String, songIds: Set<String>) {
         if (nodeId.isBlank()) return
         watchSongIdsByNodeId[nodeId] = songIds
@@ -258,6 +273,26 @@ class PhoneWatchTransferStateStore @Inject constructor() {
         }
         _watchSongIds.value = watchSongIdsByNodeId.values.flatten().toSet()
         updateWatchLibraryResolution()
+    }
+
+    /**
+     * Whether [playlistId] has been synced to a watch that's currently reachable — the honest
+     * answer to "have I sent this playlist before", which song presence can only approximate
+     * (two playlists sharing one song would both look already-sent).
+     */
+    fun isPlaylistOnAnyReachableWatch(playlistId: String): Boolean {
+        if (playlistId.isBlank()) return false
+        return _reachableWatchNodeIds.value.any { nodeId ->
+            watchPlaylistIdsByNodeId[nodeId]?.contains(playlistId) == true
+        }
+    }
+
+    fun markPlaylistPresentOnWatch(nodeId: String, playlistId: String) {
+        if (nodeId.isBlank() || playlistId.isBlank()) return
+        val existing = watchPlaylistIdsByNodeId[nodeId].orEmpty()
+        if (playlistId in existing) return
+        watchPlaylistIdsByNodeId[nodeId] = existing + playlistId
+        _watchPlaylistIds.value = watchPlaylistIdsByNodeId.values.flatten().toSet()
     }
 
     fun beginWatchLibraryRefresh(nodeIds: Set<String>) {
@@ -295,8 +330,14 @@ class PhoneWatchTransferStateStore @Inject constructor() {
                 watchSongIdsByNodeId.remove(nodeId)
             }
         }
+        watchPlaylistIdsByNodeId.keys.toList().forEach { nodeId ->
+            if (nodeId !in nodeIds) {
+                watchPlaylistIdsByNodeId.remove(nodeId)
+            }
+        }
         _watchLibrarySyncedNodeIds.value = _watchLibrarySyncedNodeIds.value.intersect(nodeIds)
         _watchSongIds.value = watchSongIdsByNodeId.values.flatten().toSet()
+        _watchPlaylistIds.value = watchPlaylistIdsByNodeId.values.flatten().toSet()
         updateWatchLibraryResolution()
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStore.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStore.kt
@@ -96,6 +96,14 @@ class PhoneWatchTransferStateStore @Inject constructor() {
     val playlistSyncAcks: SharedFlow<WearPlaylistSyncAck> = _playlistSyncAcks.asSharedFlow()
 
     private val cleanupJobs = ConcurrentHashMap<String, Job>()
+    private val watchAckTimeoutJobs = ConcurrentHashMap<String, Job>()
+
+    /**
+     * Deliberately an instance property, not a companion `const`: tests shrink it on their own
+     * store instance instead of mutating shared static state (same reasoning as
+     * [PlaylistWatchTransferCoordinator.songTransferAwaitTimeoutMs]).
+     */
+    internal var watchAckTimeoutMs: Long = DEFAULT_WATCH_ACK_TIMEOUT_MS
 
     fun onPlaylistSyncAckReceived(ack: WearPlaylistSyncAck) {
         _playlistSyncAcks.tryEmit(ack)
@@ -193,10 +201,53 @@ class PhoneWatchTransferStateStore @Inject constructor() {
             status == WearTransferProgress.STATUS_FAILED ||
             status == WearTransferProgress.STATUS_CANCELLED
         ) {
+            cancelWatchAckTimeout(requestId)
             scheduleTerminalCleanup(requestId)
         } else {
             cleanupJobs.remove(requestId)?.cancel()
+            if (status == WearTransferProgress.STATUS_AWAITING_WATCH_ACK) {
+                scheduleWatchAckTimeout(requestId, songId)
+            } else {
+                cancelWatchAckTimeout(requestId)
+            }
         }
+    }
+
+    /**
+     * A save-to-library transfer parks in [WearTransferProgress.STATUS_AWAITING_WATCH_ACK] once
+     * the bytes are on the wire, waiting for the watch's own write-complete report. That report
+     * can simply never arrive — Bluetooth drops right after the last chunk, or the watch app is
+     * killed before it can send it — and nothing else would ever move the entry out of that
+     * non-terminal state: [scheduleTerminalCleanup] only evicts terminal ones, so the transfer
+     * would pin [WatchTransferForegroundService]'s notification and the library's "sending"
+     * badge for the rest of the process's life.
+     *
+     * Lives here rather than in [PhoneDirectWatchTransferCoordinator] so it covers the lone
+     * single-song path too ([WearPhoneTransferSender.requestSongTransfer] is fire-and-forget,
+     * with no await to time out), not just the batch path that has its own backstop.
+     */
+    private fun scheduleWatchAckTimeout(requestId: String, songId: String) {
+        watchAckTimeoutJobs.remove(requestId)?.cancel()
+        watchAckTimeoutJobs[requestId] = scope.launch {
+            delay(watchAckTimeoutMs)
+            val stillAwaiting = _transfers.value[requestId]
+                ?.status == WearTransferProgress.STATUS_AWAITING_WATCH_ACK
+            watchAckTimeoutJobs.remove(requestId)
+            if (stillAwaiting) {
+                markProgress(
+                    requestId = requestId,
+                    songId = songId,
+                    bytesTransferred = 0L,
+                    totalBytes = 0L,
+                    status = WearTransferProgress.STATUS_FAILED,
+                    error = "Timed out waiting for watch confirmation",
+                )
+            }
+        }
+    }
+
+    private fun cancelWatchAckTimeout(requestId: String) {
+        watchAckTimeoutJobs.remove(requestId)?.cancel()
     }
 
     fun updateWatchSongIds(nodeId: String, songIds: Set<String>) {
@@ -225,6 +276,7 @@ class PhoneWatchTransferStateStore @Inject constructor() {
 
     fun markCancelled(requestId: String, error: String? = null) {
         cleanupJobs.remove(requestId)?.cancel()
+        cancelWatchAckTimeout(requestId)
         _transfers.update { map ->
             val current = map[requestId] ?: return@update map
             map + (requestId to current.copy(
@@ -410,7 +462,13 @@ class PhoneWatchTransferStateStore @Inject constructor() {
         }
     }
 
-    private companion object {
+    internal companion object {
         const val TERMINAL_STATE_VISIBILITY_MS = 3500L
+
+        // Comfortably longer than a healthy watch's write-and-report round trip (near-instant
+        // once the bytes have landed), and comfortably shorter than
+        // PlaylistWatchTransferCoordinator's own 300s per-song await, so a batch still sees the
+        // failure and gets to retry the song instead of timing out around it.
+        const val DEFAULT_WATCH_ACK_TIMEOUT_MS = 120_000L
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStore.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStore.kt
@@ -1,5 +1,6 @@
 package com.theveloper.pixelplay.data.service.wear
 
+import com.theveloper.pixelplay.shared.WearPlaylistSyncAck
 import com.theveloper.pixelplay.shared.WearTransferProgress
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -8,8 +9,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -33,11 +37,36 @@ data class PhoneWatchTransferState(
         }
 }
 
+/**
+ * Aggregate state of a whole-playlist watch transfer, driven by [PlaylistWatchTransferCoordinator].
+ * [currentSongProgress] is the 0f..1f progress of whichever song [activeRequestId] refers to
+ * (weighted across transcode+transfer phases by the coordinator) — the per-song byte-level detail
+ * lives in [PhoneWatchTransferState], keyed by that same requestId.
+ */
+data class PhoneWatchBatchTransferState(
+    val batchId: String,
+    val playlistId: String,
+    val playlistName: String,
+    val totalSongCount: Int,
+    val completedSongCount: Int = 0,
+    val failedSongCount: Int = 0,
+    val status: String = WearTransferProgress.STATUS_TRANSFERRING,
+    val activeRequestId: String? = null,
+    val currentSongTitle: String = "",
+    val currentSongProgress: Float = 0f,
+    val errorMessage: String? = null,
+    val updatedAtMillis: Long = System.currentTimeMillis(),
+) {
+    val processedSongCount: Int get() = completedSongCount + failedSongCount
+}
+
 @Singleton
 class PhoneWatchTransferStateStore @Inject constructor() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val _transfers = MutableStateFlow<Map<String, PhoneWatchTransferState>>(emptyMap())
     val transfers: StateFlow<Map<String, PhoneWatchTransferState>> = _transfers.asStateFlow()
+    private val _batchTransfers = MutableStateFlow<Map<String, PhoneWatchBatchTransferState>>(emptyMap())
+    val batchTransfers: StateFlow<Map<String, PhoneWatchBatchTransferState>> = _batchTransfers.asStateFlow()
     private val _reachableWatchNodeIds = MutableStateFlow<Set<String>>(emptySet())
     val reachableWatchNodeIds: StateFlow<Set<String>> = _reachableWatchNodeIds.asStateFlow()
     private val _watchLibrarySyncedNodeIds = MutableStateFlow<Set<String>>(emptySet())
@@ -48,7 +77,29 @@ class PhoneWatchTransferStateStore @Inject constructor() {
     private val _watchSongIds = MutableStateFlow<Set<String>>(emptySet())
     val watchSongIds: StateFlow<Set<String>> = _watchSongIds.asStateFlow()
 
+    // Distinct from reachableWatchNodeIds: "ever paired" (CapabilityClient FILTER_ALL) vs
+    // "reachable right now" (FILTER_REACHABLE). Defaults to false — safer to hide watch-related
+    // UI for someone who's never paired a watch than to flash it on before the first check
+    // resolves. See WearPhoneTransferSender.refreshWatchPairingState().
+    private val _isAnyWatchPaired = MutableStateFlow(false)
+    val isAnyWatchPaired: StateFlow<Boolean> = _isAnyWatchPaired.asStateFlow()
+
+    fun setAnyWatchPaired(paired: Boolean) {
+        _isAnyWatchPaired.value = paired
+    }
+
+    // Replay a handful rather than 0: the ack can in principle arrive and be emitted before
+    // PlaylistWatchTransferCoordinator starts collecting for it (right after messageClient's own
+    // send call returns), and a plain event stream with no replay would silently drop it in that
+    // case instead of just delivering it a moment "late" to a fresh collector.
+    private val _playlistSyncAcks = MutableSharedFlow<WearPlaylistSyncAck>(replay = 8)
+    val playlistSyncAcks: SharedFlow<WearPlaylistSyncAck> = _playlistSyncAcks.asSharedFlow()
+
     private val cleanupJobs = ConcurrentHashMap<String, Job>()
+
+    fun onPlaylistSyncAckReceived(ack: WearPlaylistSyncAck) {
+        _playlistSyncAcks.tryEmit(ack)
+    }
 
     fun markRequested(
         requestId: String,
@@ -229,6 +280,133 @@ class PhoneWatchTransferStateStore @Inject constructor() {
                 }
             }
             cleanupJobs.remove(requestId)
+        }
+    }
+
+    // --- Playlist batch transfers, driven by PlaylistWatchTransferCoordinator ---
+
+    private val batchCleanupJobs = ConcurrentHashMap<String, Job>()
+
+    fun markBatchStarted(batchId: String, playlistId: String, playlistName: String, totalSongCount: Int) {
+        batchCleanupJobs.remove(batchId)?.cancel()
+        _batchTransfers.update { map ->
+            map + (batchId to PhoneWatchBatchTransferState(
+                batchId = batchId,
+                playlistId = playlistId,
+                playlistName = playlistName,
+                totalSongCount = totalSongCount,
+                status = WearTransferProgress.STATUS_TRANSFERRING,
+            ))
+        }
+    }
+
+    fun markBatchSongStarted(
+        batchId: String,
+        activeRequestId: String,
+        songTitle: String,
+        startingProgress: Float = 0f,
+    ) {
+        _batchTransfers.update { map ->
+            val current = map[batchId] ?: return@update map
+            map + (batchId to current.copy(
+                activeRequestId = activeRequestId,
+                currentSongTitle = songTitle,
+                currentSongProgress = startingProgress.coerceIn(0f, 1f),
+                updatedAtMillis = System.currentTimeMillis(),
+            ))
+        }
+    }
+
+    /** [status] is informational only here — [progress] is what actually drives the notification/UI. */
+    fun markBatchSongProgress(batchId: String, status: String, progress: Float) {
+        _batchTransfers.update { map ->
+            val current = map[batchId] ?: return@update map
+            map + (batchId to current.copy(
+                currentSongProgress = progress.coerceIn(0f, 1f),
+                updatedAtMillis = System.currentTimeMillis(),
+            ))
+        }
+    }
+
+    fun markBatchSongCompleted(batchId: String) {
+        _batchTransfers.update { map ->
+            val current = map[batchId] ?: return@update map
+            map + (batchId to current.copy(
+                completedSongCount = current.completedSongCount + 1,
+                activeRequestId = null,
+                currentSongProgress = 0f,
+                updatedAtMillis = System.currentTimeMillis(),
+            ))
+        }
+    }
+
+    fun markBatchSongFailed(batchId: String, errorMessage: String? = null) {
+        _batchTransfers.update { map ->
+            val current = map[batchId] ?: return@update map
+            map + (batchId to current.copy(
+                failedSongCount = current.failedSongCount + 1,
+                activeRequestId = null,
+                currentSongProgress = 0f,
+                errorMessage = errorMessage ?: current.errorMessage,
+                updatedAtMillis = System.currentTimeMillis(),
+            ))
+        }
+    }
+
+    fun markBatchCancelled(batchId: String) {
+        _batchTransfers.update { map ->
+            val current = map[batchId] ?: return@update map
+            map + (batchId to current.copy(
+                status = WearTransferProgress.STATUS_CANCELLED,
+                activeRequestId = null,
+                updatedAtMillis = System.currentTimeMillis(),
+            ))
+        }
+        scheduleBatchTerminalCleanup(batchId)
+    }
+
+    fun markBatchFailed(batchId: String, errorMessage: String) {
+        _batchTransfers.update { map ->
+            val current = map[batchId] ?: return@update map
+            map + (batchId to current.copy(
+                status = WearTransferProgress.STATUS_FAILED,
+                errorMessage = errorMessage,
+                activeRequestId = null,
+                updatedAtMillis = System.currentTimeMillis(),
+            ))
+        }
+        scheduleBatchTerminalCleanup(batchId)
+    }
+
+    fun markBatchCompleted(batchId: String) {
+        _batchTransfers.update { map ->
+            val current = map[batchId] ?: return@update map
+            map + (batchId to current.copy(
+                status = WearTransferProgress.STATUS_COMPLETED,
+                activeRequestId = null,
+                updatedAtMillis = System.currentTimeMillis(),
+            ))
+        }
+        scheduleBatchTerminalCleanup(batchId)
+    }
+
+    private fun scheduleBatchTerminalCleanup(batchId: String) {
+        batchCleanupJobs.remove(batchId)?.cancel()
+        batchCleanupJobs[batchId] = scope.launch {
+            delay(TERMINAL_STATE_VISIBILITY_MS)
+            _batchTransfers.update { map ->
+                val current = map[batchId]
+                if (current != null &&
+                    (current.status == WearTransferProgress.STATUS_COMPLETED ||
+                        current.status == WearTransferProgress.STATUS_FAILED ||
+                        current.status == WearTransferProgress.STATUS_CANCELLED)
+                ) {
+                    map - batchId
+                } else {
+                    map
+                }
+            }
+            batchCleanupJobs.remove(batchId)
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistBatchTransferPersistence.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistBatchTransferPersistence.kt
@@ -1,0 +1,87 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+/**
+ * A playlist batch transfer request, in just enough detail to resume it after the phone process
+ * dies mid-transfer — a realistic outcome for a transfer that can run tens of minutes over
+ * Bluetooth, not a theoretical one (see the plan's §R-06). [songIds] is the original request, not
+ * whatever subset was still pending when the process died: [PlaylistWatchTransferCoordinator]
+ * already re-derives which of them are still needed by asking the watch what it already has, the
+ * same way it does for a fresh, non-resumed send.
+ */
+@Serializable
+data class PersistedPlaylistBatchIntent(
+    val batchId: String,
+    val playlistId: String,
+    val playlistName: String,
+    val songIds: List<String>,
+    val requestedAtMillis: Long,
+)
+
+/**
+ * Persists at most one in-flight playlist batch intent — deliberately not the rest of
+ * [PhoneWatchTransferStateStore]'s state (per-song byte progress, reachable nodes, ...), which is
+ * UI-only, cheap to rebuild, and churns too fast to persist sensibly. Only the intent — "this
+ * playlist batch was requested and hadn't finished" — needs to survive a process restart.
+ *
+ * Reuses the app's single shared `DataStore<Preferences>` (see [com.theveloper.pixelplay.di.AppModule])
+ * rather than a dedicated file, matching the existing `*PreferencesRepository` convention.
+ */
+@Singleton
+class PlaylistBatchTransferPersistence @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun saveInFlightBatch(intent: PersistedPlaylistBatchIntent) {
+        dataStore.edit { preferences ->
+            preferences[Keys.IN_FLIGHT_BATCH] = json.encodeToString(intent)
+        }
+    }
+
+    /**
+     * No-ops if [batchId] isn't the one currently stored: a newer batch (e.g. the user sent
+     * another playlist while this one was still finishing up) may already have overwritten it,
+     * and clearing unconditionally here would drop that newer, still-in-flight intent instead.
+     */
+    suspend fun clearInFlightBatch(batchId: String) {
+        dataStore.edit { preferences ->
+            val stored = preferences[Keys.IN_FLIGHT_BATCH]?.let(::decode)
+            if (stored?.batchId == batchId) {
+                preferences.remove(Keys.IN_FLIGHT_BATCH)
+            }
+        }
+    }
+
+    suspend fun getInFlightBatch(): PersistedPlaylistBatchIntent? {
+        val stored = dataStore.data.first()[Keys.IN_FLIGHT_BATCH] ?: return null
+        return decode(stored)
+    }
+
+    private fun decode(raw: String): PersistedPlaylistBatchIntent? = try {
+        json.decodeFromString<PersistedPlaylistBatchIntent>(raw)
+    } catch (e: Exception) {
+        Timber.tag(TAG).w(e, "Failed to decode persisted playlist batch intent, discarding it")
+        null
+    }
+
+    private object Keys {
+        val IN_FLIGHT_BATCH = stringPreferencesKey("wear_playlist_batch_in_flight_v1")
+    }
+
+    private companion object {
+        const val TAG = "PlaylistBatchPersist"
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinator.kt
@@ -313,6 +313,12 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
         val ack = withTimeoutOrNull(PLAYLIST_SYNC_ACK_TIMEOUT_MS) {
             transferStateStore.playlistSyncAcks.first { it.requestId == requestId }
         }
+        if (ack != null) {
+            // The watch has confirmed it stored the playlist, so record that now rather than
+            // waiting for the next library query to discover it — this is what flips the UI from
+            // "send to watch" to "update on watch" for this playlist.
+            transferStateStore.markPlaylistPresentOnWatch(nodeId = node.id, playlistId = playlistId)
+        }
         return ack != null
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinator.kt
@@ -1,0 +1,477 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import android.app.Application
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.Node
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.repository.MusicRepository
+import com.theveloper.pixelplay.di.AppScope
+import com.theveloper.pixelplay.shared.WearCapabilities
+import com.theveloper.pixelplay.shared.WearDataPaths
+import com.theveloper.pixelplay.shared.WearPlaylistSync
+import com.theveloper.pixelplay.shared.WearPlaylistSyncAck
+import com.theveloper.pixelplay.shared.WearTransferProgress
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+/**
+ * Orchestrates sending a whole playlist to the watch: syncs the playlist's membership/order
+ * first (so the watch can show it, and start playing it, before every song has arrived), then
+ * transfers songs that aren't already on the watch one at a time — never in parallel, to avoid
+ * saturating the single Bluetooth channel and spiking CPU/battery on the watch (see
+ * [WatchAudioTranscoder]'s doc for why the encode itself is also sequential per song).
+ *
+ * Reuses the existing single-song pipeline end to end: [WatchAudioTranscoder] decides/produces
+ * the audio to send, and [PhoneDirectWatchTransferCoordinator] still owns the actual chunked
+ * ChannelClient streaming (via its [PhoneDirectWatchTransferCoordinator.WatchAudioOverride] hook)
+ * and per-song cancellation.
+ */
+@Singleton
+class PlaylistWatchTransferCoordinator @Inject constructor(
+    private val application: Application,
+    private val musicRepository: MusicRepository,
+    private val watchAudioTranscoder: WatchAudioTranscoder,
+    private val directTransferCoordinator: PhoneDirectWatchTransferCoordinator,
+    private val wearPhoneTransferSender: WearPhoneTransferSender,
+    private val transferStateStore: PhoneWatchTransferStateStore,
+    private val batchPersistence: PlaylistBatchTransferPersistence,
+    // Injected directly (unlike most of this package, which resolves these via
+    // Wearable.getXClient(application) internally) so this coordinator is constructible with
+    // fakes in tests without needing to mock a static Java method.
+    private val capabilityClient: CapabilityClient,
+    private val messageClient: MessageClient,
+    @AppScope private val scope: CoroutineScope,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val cancelledBatchIds = ConcurrentHashMap.newKeySet<String>()
+
+    /**
+     * Deliberately an instance property, not a companion `const`/`var`: tests shrink it on their
+     * own coordinator instance, so runs never leak a mutated timeout into unrelated tests the way
+     * a shared static field would.
+     */
+    internal var songTransferAwaitTimeoutMs: Long = DEFAULT_SONG_TRANSFER_AWAIT_TIMEOUT_MS
+
+    /** Returns the generated batchId immediately; the transfer itself runs asynchronously. */
+    fun requestPlaylistTransfer(playlistId: String, playlistName: String, songIds: List<String>): String {
+        val batchId = UUID.randomUUID().toString()
+        if (songIds.isEmpty()) return batchId
+
+        scope.launch {
+            runBatchTransfer(batchId, playlistId, playlistName, songIds)
+        }
+        return batchId
+    }
+
+    fun cancelPlaylistTransfer(batchId: String) {
+        cancelledBatchIds.add(batchId)
+        val activeRequestId = transferStateStore.batchTransfers.value[batchId]?.activeRequestId
+        if (activeRequestId != null) {
+            scope.launch { wearPhoneTransferSender.cancelTransfer(activeRequestId) }
+        }
+        transferStateStore.markBatchCancelled(batchId)
+        scope.launch { batchPersistence.clearInFlightBatch(batchId) }
+    }
+
+    /**
+     * Called once at process start ([com.theveloper.pixelplay.PixelPlayApplication]). If the
+     * process died mid-transfer last time, [PlaylistBatchTransferPersistence] still has that
+     * batch's intent — re-running it from scratch is safe and correct: the watch itself rejects
+     * a duplicate transfer for a song it already has (`ERROR_ALREADY_ON_WATCH`), and
+     * [runBatchTransfer] already skips anything [PhoneWatchTransferStateStore] can confirm is
+     * already there. That confirmation is only as good as the watch-library snapshot in memory —
+     * empty right after a cold start — so this waits (briefly) for a fresh one before resuming,
+     * instead of re-attempting everything and relying solely on the watch's own rejection.
+     */
+    suspend fun resumePersistedBatchIfNeeded() {
+        val persisted = batchPersistence.getInFlightBatch() ?: return
+        Timber.tag(TAG).i(
+            "Resuming playlist transfer interrupted by process death: playlistId=%s (%d songs)",
+            persisted.playlistId,
+            persisted.songIds.size,
+        )
+        runCatching { wearPhoneTransferSender.refreshWatchLibraryState() }
+        withTimeoutOrNull(WATCH_LIBRARY_RESOLVE_TIMEOUT_MS) {
+            transferStateStore.isWatchLibraryResolved.first { it }
+        }
+        requestPlaylistTransfer(persisted.playlistId, persisted.playlistName, persisted.songIds)
+    }
+
+    private suspend fun runBatchTransfer(
+        batchId: String,
+        playlistId: String,
+        playlistName: String,
+        songIds: List<String>,
+    ) {
+        batchPersistence.saveInFlightBatch(
+            PersistedPlaylistBatchIntent(
+                batchId = batchId,
+                playlistId = playlistId,
+                playlistName = playlistName,
+                songIds = songIds,
+                requestedAtMillis = System.currentTimeMillis(),
+            )
+        )
+
+        val nodes = resolveReachableNodes()
+        transferStateStore.markBatchStarted(batchId, playlistId, playlistName, songIds.size)
+
+        if (nodes.isEmpty()) {
+            transferStateStore.markBatchFailed(batchId, "No reachable watch with PixelPlay")
+            batchPersistence.clearInFlightBatch(batchId)
+            return
+        }
+        transferStateStore.retainReachableWatchNodes(nodes.map { it.id }.toSet())
+
+        WatchTransferForegroundService.start(application)
+        val songTitles = resolveSongTitlesInOrder(songIds)
+        sendPlaylistSyncToNodes(nodes, playlistId, playlistName, songIds, songTitles)
+
+        val alreadyPresentCount = songIds.count { transferStateStore.isSongSavedOnAllReachableWatches(it) }
+        repeat(alreadyPresentCount) { transferStateStore.markBatchSongCompleted(batchId) }
+
+        val pendingSongIds = songIds.filterNot { transferStateStore.isSongSavedOnAllReachableWatches(it) }
+
+        for (songId in pendingSongIds) {
+            if (cancelledBatchIds.contains(batchId)) break
+
+            val song = musicRepository.getSongsByIds(listOf(songId)).first().firstOrNull()
+            if (song == null) {
+                Timber.tag(TAG).w("Song not found for playlist transfer: songId=%s", songId)
+                transferStateStore.markBatchSongFailed(batchId)
+                continue
+            }
+
+            val outcome = transferSongToAllNodesWithRetry(batchId, nodes, song)
+            if (outcome.completed) {
+                transferStateStore.markBatchSongCompleted(batchId)
+            } else {
+                transferStateStore.markBatchSongFailed(batchId, outcome.errorCode)
+            }
+        }
+
+        cancelledBatchIds.remove(batchId)
+        if (transferStateStore.batchTransfers.value[batchId]?.status != WearTransferProgress.STATUS_CANCELLED) {
+            transferStateStore.markBatchCompleted(batchId)
+            batchPersistence.clearInFlightBatch(batchId)
+        }
+    }
+
+    private suspend fun resolveReachableNodes(): List<Node> {
+        return try {
+            capabilityClient.getCapability(
+                WearCapabilities.PIXELPLAY_WEAR_APP,
+                CapabilityClient.FILTER_REACHABLE,
+            ).await().nodes.toList()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            Timber.tag(TAG).w(error, "Failed to resolve reachable watches for playlist transfer")
+            emptyList()
+        }
+    }
+
+    /**
+     * `MessageClient.sendMessage()` succeeding only means the message was handed off locally, not
+     * that the watch received it — real hardware testing showed a sync sent while the watch was
+     * mid-reconnect (its Wi-Fi/ADB link drops intermittently under this app's own load) is
+     * silently lost: the watch ends up with every song's audio on disk but no playlist row to
+     * show them under, because nothing here ever knew the sync didn't land. Each node now gets a
+     * fresh [WearPlaylistSync.requestId] and this waits for the matching [WearPlaylistSyncAck]
+     * (see [WearTransferRepository][com.theveloper.pixelplay.data.WearTransferRepository]
+     * `.onPlaylistSyncReceived` on the watch side), retrying once — same shape as
+     * [transferSongToAllNodesWithRetry] — before giving up and logging it. Giving up doesn't fail
+     * the batch: songs still transfer either way, and the next explicit re-sync (or "update on
+     * watch") is idempotent and gets another chance.
+     */
+    private suspend fun sendPlaylistSyncToNodes(
+        nodes: List<Node>,
+        playlistId: String,
+        playlistName: String,
+        songIds: List<String>,
+        songTitles: List<String>,
+    ) {
+        nodes.forEach { node ->
+            sendPlaylistSyncToNodeWithRetry(node, playlistId, playlistName, songIds, songTitles)
+        }
+    }
+
+    private suspend fun sendPlaylistSyncToNodeWithRetry(
+        node: Node,
+        playlistId: String,
+        playlistName: String,
+        songIds: List<String>,
+        songTitles: List<String>,
+    ) {
+        if (sendPlaylistSyncToNodeAndAwaitAck(node, playlistId, playlistName, songIds, songTitles)) return
+
+        Timber.tag(TAG).w(
+            "Retrying playlist sync after missing ack: playlistId=%s node=%s",
+            playlistId,
+            node.id,
+        )
+        delay(RETRY_BACKOFF_MS)
+        val ackedOnRetry = sendPlaylistSyncToNodeAndAwaitAck(node, playlistId, playlistName, songIds, songTitles)
+        if (!ackedOnRetry) {
+            Timber.tag(TAG).w(
+                "Playlist sync unconfirmed after retry: playlistId=%s node=%s — songs will still " +
+                    "transfer, but the watch may not show this playlist until the next sync",
+                playlistId,
+                node.id,
+            )
+        }
+    }
+
+    /** Returns whether [node] acked this attempt within [PLAYLIST_SYNC_ACK_TIMEOUT_MS]. */
+    private suspend fun sendPlaylistSyncToNodeAndAwaitAck(
+        node: Node,
+        playlistId: String,
+        playlistName: String,
+        songIds: List<String>,
+        songTitles: List<String>,
+    ): Boolean {
+        val requestId = UUID.randomUUID().toString()
+        val syncPayload = json.encodeToString(
+            WearPlaylistSync(playlistId, playlistName, songIds, songTitles, requestId)
+        ).toByteArray(Charsets.UTF_8)
+
+        try {
+            messageClient.sendMessage(node.id, WearDataPaths.PLAYLIST_SYNC, syncPayload).await()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            Timber.tag(TAG).w(error, "Failed to send playlist sync to node=%s", node.id)
+            return false
+        }
+
+        val ack = withTimeoutOrNull(PLAYLIST_SYNC_ACK_TIMEOUT_MS) {
+            transferStateStore.playlistSyncAcks.first { it.requestId == requestId }
+        }
+        return ack != null
+    }
+
+    /**
+     * Titles for [songIds], same order, "" for any id the library doesn't resolve — purely
+     * cosmetic (lets the watch show a real name instead of a raw id for a song still awaiting
+     * transfer), so a missing title here is never a reason to fail or delay the sync.
+     */
+    private suspend fun resolveSongTitlesInOrder(songIds: List<String>): List<String> {
+        val songsById = musicRepository.getSongsByIds(songIds).first().associateBy { it.id }
+        return songIds.map { songId -> songsById[songId]?.title.orEmpty() }
+    }
+
+    /**
+     * Retries [song] once after a transient failure, with a short backoff. Real hardware
+     * testing showed a song can legitimately fail (watch-side idle watchdog closing a live but
+     * slow Bluetooth stream — see WearTransferRepository) while a retry moments later succeeds
+     * cleanly: the watch's Bluetooth radio is shared with any connected BT headset, and a
+     * transfer can genuinely stall for a while under that contention without anything actually
+     * being broken. Doesn't retry past a cancellation, and re-transcodes on the retry rather
+     * than caching the first attempt's output — simpler and safe (transcoding on a modern phone
+     * is a few seconds, not the bottleneck), at the cost of redoing work that likely already
+     * succeeded once.
+     */
+    private suspend fun transferSongToAllNodesWithRetry(
+        batchId: String,
+        nodes: List<Node>,
+        song: Song,
+    ): SongTransferResult {
+        val firstAttempt = transferSongToAllNodes(batchId, nodes, song)
+        if (firstAttempt.completed || cancelledBatchIds.contains(batchId)) return firstAttempt
+
+        Timber.tag(TAG).w(
+            "Retrying transfer after failure: songId=%s errorCode=%s",
+            song.id,
+            firstAttempt.errorCode,
+        )
+        delay(RETRY_BACKOFF_MS)
+        if (cancelledBatchIds.contains(batchId)) return firstAttempt
+        return transferSongToAllNodes(batchId, nodes, song)
+    }
+
+    /** Transcodes [song] once (if needed) and streams it to every reachable [nodes] in turn. */
+    private suspend fun transferSongToAllNodes(
+        batchId: String,
+        nodes: List<Node>,
+        song: Song,
+    ): SongTransferResult {
+        if (cancelledBatchIds.contains(batchId)) return SongTransferResult(completed = false)
+
+        val transcodeRequestId = UUID.randomUUID().toString()
+        transferStateStore.markBatchSongStarted(batchId, transcodeRequestId, song.title)
+
+        val transcodeResult = watchAudioTranscoder.transcodeIfNeeded(
+            song = song,
+            requestId = transcodeRequestId,
+            onProgress = { fraction ->
+                transferStateStore.markBatchSongProgress(
+                    batchId,
+                    WearTransferProgress.STATUS_TRANSCODING,
+                    fraction.coerceIn(0f, 1f) * TRANSCODE_PHASE_WEIGHT,
+                )
+            },
+        )
+        if (transcodeResult is WatchAudioTranscoder.TranscodeResult.Failed) {
+            Timber.tag(TAG).w(transcodeResult.error, "Transcode failed for songId=%s, skipping", song.id)
+            return SongTransferResult(completed = false, errorCode = WearTransferProgress.ERROR_CODE_GENERIC)
+        }
+        if (cancelledBatchIds.contains(batchId)) {
+            watchAudioTranscoder.cleanup(transcodeResult)
+            return SongTransferResult(completed = false)
+        }
+
+        val audioOverride = (transcodeResult as? WatchAudioTranscoder.TranscodeResult.Transcoded)?.let { transcoded ->
+            PhoneDirectWatchTransferCoordinator.WatchAudioOverride(
+                file = transcoded.outputFile,
+                mimeType = WatchAudioTranscoder.TRANSCODED_OUTPUT_MIME_TYPE,
+                bitrateBps = WatchAudioTranscoder.TARGET_BITRATE_BPS,
+            )
+        }
+        val wasTranscoded = audioOverride != null
+
+        // Send to every reachable node (not just the first) — with multiple paired watches this
+        // song should land on all of them. Present on at least one counts as done overall; if
+        // every node failed, report whichever node failed last (good enough for the UI's
+        // single-line failure summary).
+        var succeededOnAnyNode = false
+        var lastFailureErrorCode: String? = null
+        for (node in nodes) {
+            if (cancelledBatchIds.contains(batchId)) break
+            val nodeOutcome = transferSongToNode(batchId, node, song, audioOverride, wasTranscoded)
+            if (nodeOutcome.completed) {
+                succeededOnAnyNode = true
+            } else {
+                lastFailureErrorCode = nodeOutcome.errorCode
+            }
+        }
+
+        watchAudioTranscoder.cleanup(transcodeResult)
+        return SongTransferResult(
+            completed = succeededOnAnyNode,
+            errorCode = if (succeededOnAnyNode) null else lastFailureErrorCode,
+        )
+    }
+
+    private suspend fun transferSongToNode(
+        batchId: String,
+        node: Node,
+        song: Song,
+        audioOverride: PhoneDirectWatchTransferCoordinator.WatchAudioOverride?,
+        wasTranscoded: Boolean,
+    ): SongTransferResult {
+        val requestId = UUID.randomUUID().toString()
+        // Re-targets activeRequestId to this node's request without resetting the visible
+        // progress: if the song was transcoded, it's already sitting at TRANSCODE_PHASE_WEIGHT.
+        val startingProgress = if (wasTranscoded) TRANSCODE_PHASE_WEIGHT else 0f
+        transferStateStore.markBatchSongStarted(batchId, requestId, song.title, startingProgress)
+
+        val progressWatcherJob: Job = scope.launch {
+            transferStateStore.transfers
+                .mapNotNull { it[requestId] }
+                .collect { state ->
+                    if (state.status == WearTransferProgress.STATUS_TRANSFERRING) {
+                        // Transferring is the second phase for a transcoded song: continue from
+                        // TRANSCODE_PHASE_WEIGHT up to 1.0 instead of restarting at 0.
+                        val overallProgress = if (wasTranscoded) {
+                            TRANSCODE_PHASE_WEIGHT + state.progress * (1f - TRANSCODE_PHASE_WEIGHT)
+                        } else {
+                            state.progress
+                        }
+                        transferStateStore.markBatchSongProgress(batchId, state.status, overallProgress)
+                    }
+                }
+        }
+
+        directTransferCoordinator.startTransferToWatch(
+            nodeId = node.id,
+            requestId = requestId,
+            songId = song.id,
+            audioOverride = audioOverride,
+        )
+
+        val finalState = withTimeoutOrNull(songTransferAwaitTimeoutMs) {
+            transferStateStore.transfers
+                .mapNotNull { it[requestId] }
+                .first { it.status in TERMINAL_STATUSES }
+        }
+        progressWatcherJob.cancel()
+
+        if (finalState == null) {
+            Timber.tag(TAG).w(
+                "Timed out awaiting watch confirmation: songId=%s requestId=%s",
+                song.id,
+                requestId,
+            )
+            transferStateStore.markProgress(
+                requestId = requestId,
+                songId = song.id,
+                bytesTransferred = 0L,
+                totalBytes = 0L,
+                status = WearTransferProgress.STATUS_FAILED,
+                error = "Timed out waiting for watch confirmation",
+            )
+            return SongTransferResult(completed = false, errorCode = WearTransferProgress.ERROR_CODE_TIMED_OUT)
+        }
+
+        return SongTransferResult(
+            completed = finalState.status == WearTransferProgress.STATUS_COMPLETED,
+            errorCode = if (finalState.status == WearTransferProgress.STATUS_FAILED) {
+                WearTransferProgress.ERROR_CODE_GENERIC
+            } else {
+                null
+            },
+        )
+    }
+
+    private data class SongTransferResult(val completed: Boolean, val errorCode: String? = null)
+
+    internal companion object {
+        private const val TAG = "PlaylistWatchTransfer"
+
+        // Transcoding and transferring both report 0f..1f progress for the same song; weighting
+        // them into one continuous 0..1 scale (instead of each resetting to 0) avoids the visible
+        // jump-then-reset when a song moves from one phase to the other.
+        private const val TRANSCODE_PHASE_WEIGHT = 0.3f
+
+        // Deliberately generous relative to the watch's own idle watchdog: leaves room for slow
+        // transcoding plus a slow Bluetooth link on large files. Better to wait too long than to
+        // mark a legitimately-slow transfer as failed.
+        private const val DEFAULT_SONG_TRANSFER_AWAIT_TIMEOUT_MS = 300_000L
+
+        // Short on purpose: a retry exists for transient stalls (radio contention with a
+        // connected BT headset, momentary Bluetooth hiccups), not to wait out a genuinely dead
+        // link — a longer backoff would just make a real failure take longer to report.
+        private const val RETRY_BACKOFF_MS = 3_000L
+
+        // How long resumePersistedBatchIfNeeded() waits for a fresh watch-library snapshot before
+        // giving up and resuming anyway. Short: this only avoids some wasted duplicate-rejected
+        // round-trips, it's not load-bearing for correctness (the watch rejects duplicates itself).
+        private const val WATCH_LIBRARY_RESOLVE_TIMEOUT_MS = 10_000L
+
+        // How long to wait for the watch's playlist-sync ack before retrying. Generous relative to
+        // a normal round-trip (which is near-instant) to tolerate a brief Wi-Fi/ADB reconnect blip
+        // without firing a spurious retry.
+        private const val PLAYLIST_SYNC_ACK_TIMEOUT_MS = 10_000L
+
+        private val TERMINAL_STATUSES = setOf(
+            WearTransferProgress.STATUS_COMPLETED,
+            WearTransferProgress.STATUS_FAILED,
+            WearTransferProgress.STATUS_CANCELLED,
+        )
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinator.kt
@@ -68,12 +68,27 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
     internal var songTransferAwaitTimeoutMs: Long = DEFAULT_SONG_TRANSFER_AWAIT_TIMEOUT_MS
 
     /** Returns the generated batchId immediately; the transfer itself runs asynchronously. */
-    fun requestPlaylistTransfer(playlistId: String, playlistName: String, songIds: List<String>): String {
+    fun requestPlaylistTransfer(playlistId: String, playlistName: String, songIds: List<String>): String =
+        startBatch(
+            playlistId = playlistId,
+            playlistName = playlistName,
+            songIds = songIds,
+            requestedAtMillis = System.currentTimeMillis(),
+            isResume = false,
+        )
+
+    private fun startBatch(
+        playlistId: String,
+        playlistName: String,
+        songIds: List<String>,
+        requestedAtMillis: Long,
+        isResume: Boolean,
+    ): String {
         val batchId = UUID.randomUUID().toString()
         if (songIds.isEmpty()) return batchId
 
         scope.launch {
-            runBatchTransfer(batchId, playlistId, playlistName, songIds)
+            runBatchTransfer(batchId, playlistId, playlistName, songIds, requestedAtMillis, isResume)
         }
         return batchId
     }
@@ -100,6 +115,16 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
      */
     suspend fun resumePersistedBatchIfNeeded() {
         val persisted = batchPersistence.getInFlightBatch() ?: return
+        val age = System.currentTimeMillis() - persisted.requestedAtMillis
+        if (age > MAX_RESUME_AGE_MS) {
+            Timber.tag(TAG).i(
+                "Discarding stale playlist transfer intent: playlistId=%s age=%dms",
+                persisted.playlistId,
+                age,
+            )
+            batchPersistence.clearInFlightBatch(persisted.batchId)
+            return
+        }
         Timber.tag(TAG).i(
             "Resuming playlist transfer interrupted by process death: playlistId=%s (%d songs)",
             persisted.playlistId,
@@ -109,7 +134,16 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
         withTimeoutOrNull(WATCH_LIBRARY_RESOLVE_TIMEOUT_MS) {
             transferStateStore.isWatchLibraryResolved.first { it }
         }
-        requestPlaylistTransfer(persisted.playlistId, persisted.playlistName, persisted.songIds)
+        startBatch(
+            playlistId = persisted.playlistId,
+            playlistName = persisted.playlistName,
+            songIds = persisted.songIds,
+            // Carries the *original* request's timestamp forward: a resume re-saves the intent
+            // under a fresh batchId, and stamping it "now" every time would make the intent
+            // immortal, since its age could then never reach MAX_RESUME_AGE_MS.
+            requestedAtMillis = persisted.requestedAtMillis,
+            isResume = true,
+        )
     }
 
     private suspend fun runBatchTransfer(
@@ -117,6 +151,8 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
         playlistId: String,
         playlistName: String,
         songIds: List<String>,
+        requestedAtMillis: Long,
+        isResume: Boolean,
     ) {
         batchPersistence.saveInFlightBatch(
             PersistedPlaylistBatchIntent(
@@ -124,7 +160,7 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
                 playlistId = playlistId,
                 playlistName = playlistName,
                 songIds = songIds,
-                requestedAtMillis = System.currentTimeMillis(),
+                requestedAtMillis = requestedAtMillis,
             )
         )
 
@@ -132,8 +168,15 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
         transferStateStore.markBatchStarted(batchId, playlistId, playlistName, songIds.size)
 
         if (nodes.isEmpty()) {
+            cancelledBatchIds.remove(batchId)
             transferStateStore.markBatchFailed(batchId, "No reachable watch with PixelPlay")
-            batchPersistence.clearInFlightBatch(batchId)
+            // A resumed batch keeps its intent: "no watch in range right now" is exactly the case
+            // the persistence exists for — a resume at a cold start routinely lands with the watch
+            // off the wrist or out of Bluetooth range, and clearing here would lose the
+            // interrupted transfer for good. It ages out via MAX_RESUME_AGE_MS instead.
+            // A brand-new request that can't find a watch is just a failed request, and is cleared
+            // as before: the user saw it fail and would not expect it to reappear days later.
+            if (!isResume) batchPersistence.clearInFlightBatch(batchId)
             return
         }
         transferStateStore.retainReachableWatchNodes(nodes.map { it.id }.toSet())
@@ -165,11 +208,19 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
             }
         }
 
-        cancelledBatchIds.remove(batchId)
-        if (transferStateStore.batchTransfers.value[batchId]?.status != WearTransferProgress.STATUS_CANCELLED) {
+        // Reads the cancellation from cancelledBatchIds rather than from the store's status:
+        // cancelPlaylistTransfer() can land before runBatchTransfer() has called markBatchStarted,
+        // in which case markBatchCancelled found no entry to update and no-opped — leaving a
+        // status that isn't CANCELLED for a batch the user did cancel, reported to them as a
+        // successfully completed transfer of zero songs.
+        val wasCancelled = cancelledBatchIds.remove(batchId) ||
+            transferStateStore.batchTransfers.value[batchId]?.status == WearTransferProgress.STATUS_CANCELLED
+        if (wasCancelled) {
+            transferStateStore.markBatchCancelled(batchId)
+        } else {
             transferStateStore.markBatchCompleted(batchId)
-            batchPersistence.clearInFlightBatch(batchId)
         }
+        batchPersistence.clearInFlightBatch(batchId)
     }
 
     private suspend fun resolveReachableNodes(): List<Node> {
@@ -428,6 +479,19 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
             return SongTransferResult(completed = false, errorCode = WearTransferProgress.ERROR_CODE_TIMED_OUT)
         }
 
+        // The watch rejecting a song it already has is a success for this batch's purposes, not a
+        // failure: treating it as one made transferSongToAllNodesWithRetry re-transcode and
+        // re-offer the very same song, get rejected again, and then report it to the user as
+        // failed. It also teaches the state store the song really is on this node — the outcome
+        // handler only learns that from a COMPLETED — so the rest of the batch (and the next one)
+        // can skip it up front.
+        val alreadyOnWatch = finalState.status == WearTransferProgress.STATUS_FAILED &&
+            finalState.error == WearTransferProgress.ERROR_ALREADY_ON_WATCH
+        if (alreadyOnWatch) {
+            transferStateStore.markSongPresentOnWatch(nodeId = node.id, songId = song.id)
+            return SongTransferResult(completed = true)
+        }
+
         return SongTransferResult(
             completed = finalState.status == WearTransferProgress.STATUS_COMPLETED,
             errorCode = if (finalState.status == WearTransferProgress.STATUS_FAILED) {
@@ -462,6 +526,12 @@ class PlaylistWatchTransferCoordinator @Inject constructor(
         // giving up and resuming anyway. Short: this only avoids some wasted duplicate-rejected
         // round-trips, it's not load-bearing for correctness (the watch rejects duplicates itself).
         private const val WATCH_LIBRARY_RESOLVE_TIMEOUT_MS = 10_000L
+
+        // How stale a persisted intent may be before resumePersistedBatchIfNeeded() drops it
+        // instead of resuming. A transfer interrupted by process death is worth retrying across
+        // the next few launches (the watch may simply have been out of range each time), but a
+        // playlist the user asked for a week ago and has since forgotten about isn't.
+        private const val MAX_RESUME_AGE_MS = 7L * 24 * 60 * 60 * 1000
 
         // How long to wait for the watch's playlist-sync ack before retrying. Generous relative to
         // a normal round-trip (which is near-instant) to tolerate a brief Wi-Fi/ADB reconnect blip

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoder.kt
@@ -1,0 +1,216 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import android.app.Application
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.transformer.AudioEncoderSettings
+import androidx.media3.transformer.Composition
+import androidx.media3.transformer.DefaultEncoderFactory
+import androidx.media3.transformer.ExportException
+import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.ProgressHolder
+import androidx.media3.transformer.Transformer
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.di.MainDispatcher
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+/**
+ * Decides whether a song needs to be re-encoded before it is sent to the watch, and performs
+ * that re-encoding with [Transformer].
+ *
+ * Lossless/high-bitrate sources are re-encoded to AAC-LC at [TARGET_BITRATE_BPS]: watches decode
+ * AAC in hardware but most FLAC decoding on Wear OS SoCs is software-only, and lossless files are
+ * also far larger to transfer and store on a watch's very limited flash. Sources that are already
+ * a compressed lossy format at or below the passthrough bitrate are sent through untouched (see
+ * [PhoneDirectWatchTransferCoordinator]) — re-encoding an already-small MP3 down to
+ * [TARGET_BITRATE_BPS] would only cost CPU and quality for no size benefit worth the transfer
+ * time saved.
+ */
+@UnstableApi
+@Singleton
+class WatchAudioTranscoder @Inject constructor(
+    private val application: Application,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+) {
+
+    sealed class TranscodeResult {
+        /** The source is already an acceptable lossy format; send it as-is. */
+        data object Passthrough : TranscodeResult()
+        data class Transcoded(val outputFile: File) : TranscodeResult()
+        data class Failed(val error: Throwable) : TranscodeResult()
+    }
+
+    /** Pure decision function, kept separate from the actual encode so it's cheap to unit test. */
+    fun requiresTranscoding(song: Song): Boolean {
+        val mimeType = song.mimeType?.lowercase(Locale.ROOT)
+        val bitrate = song.bitrate
+        val isPassthroughEligible = mimeType != null &&
+            PASSTHROUGH_MIME_TYPES.contains(mimeType) &&
+            bitrate != null &&
+            bitrate <= MAX_PASSTHROUGH_BITRATE_BPS
+        return !isPassthroughEligible
+    }
+
+    /**
+     * Runs the transcode if [requiresTranscoding] says it's needed, reporting encode progress
+     * as a 0f..1f fraction via [onProgress]. Callers own [TranscodeResult.Transcoded.outputFile]
+     * and must delete it (via [cleanup]) once it has been sent or the transfer is abandoned.
+     */
+    suspend fun transcodeIfNeeded(
+        song: Song,
+        requestId: String,
+        onProgress: (Float) -> Unit = {},
+    ): TranscodeResult {
+        if (!requiresTranscoding(song)) return TranscodeResult.Passthrough
+
+        val inputMediaItem = buildInputMediaItem(song)
+            ?: return TranscodeResult.Failed(IllegalStateException("No readable local audio source for songId=${song.id}"))
+
+        val outputFile = outputFileFor(song.id, requestId)
+        outputFile.parentFile?.mkdirs()
+
+        return runTransform(inputMediaItem, outputFile, onProgress)
+    }
+
+    fun cleanup(result: TranscodeResult) {
+        if (result is TranscodeResult.Transcoded) {
+            runCatching { result.outputFile.delete() }
+                .onFailure { error -> Timber.tag(TAG).w(error, "Failed to delete transcoded temp file") }
+        }
+    }
+
+    // Transformer must be built and started on a thread that has a Looper — the main thread is
+    // the one Android guarantees has one, so this can't move to an injected background dispatcher.
+    private suspend fun runTransform(
+        inputMediaItem: MediaItem,
+        outputFile: File,
+        onProgress: (Float) -> Unit,
+    ): TranscodeResult = withContext(mainDispatcher) {
+        suspendCancellableCoroutine { continuation ->
+            val encoderFactory = DefaultEncoderFactory.Builder(application)
+                .setRequestedAudioEncoderSettings(
+                    AudioEncoderSettings.Builder().setBitrate(TARGET_BITRATE_BPS).build()
+                )
+                .build()
+
+            val transformer = Transformer.Builder(application)
+                .setAudioMimeType(MimeTypes.AUDIO_AAC)
+                .setEncoderFactory(encoderFactory)
+                .addListener(object : Transformer.Listener {
+                    override fun onCompleted(composition: Composition, exportResult: ExportResult) {
+                        if (continuation.isActive) {
+                            continuation.resume(TranscodeResult.Transcoded(outputFile))
+                        }
+                    }
+
+                    override fun onError(
+                        composition: Composition,
+                        exportResult: ExportResult,
+                        exportException: ExportException,
+                    ) {
+                        // Transformer does not delete partial output on failure — see its Listener docs.
+                        runCatching { outputFile.delete() }
+                        if (continuation.isActive) {
+                            continuation.resume(TranscodeResult.Failed(exportException))
+                        }
+                    }
+                })
+                .build()
+
+            continuation.invokeOnCancellation {
+                transformer.cancel()
+                runCatching { outputFile.delete() }
+            }
+
+            pollProgress(transformer, continuation, onProgress)
+
+            transformer.start(inputMediaItem, outputFile.absolutePath)
+        }
+    }
+
+    private fun pollProgress(
+        transformer: Transformer,
+        continuation: CancellableContinuation<TranscodeResult>,
+        onProgress: (Float) -> Unit,
+    ) {
+        val progressHolder = ProgressHolder()
+        val handler = android.os.Handler(android.os.Looper.getMainLooper())
+        val poll = object : Runnable {
+            override fun run() {
+                if (!continuation.isActive) return
+                val state = transformer.getProgress(progressHolder)
+                if (state == Transformer.PROGRESS_STATE_AVAILABLE) {
+                    onProgress(progressHolder.progress / 100f)
+                }
+                if (state != Transformer.PROGRESS_STATE_NOT_STARTED) {
+                    handler.postDelayed(this, PROGRESS_POLL_INTERVAL_MS)
+                }
+            }
+        }
+        handler.postDelayed(poll, PROGRESS_POLL_INTERVAL_MS)
+    }
+
+    private fun buildInputMediaItem(song: Song): MediaItem? {
+        val directFile = song.path.takeIf { it.isNotBlank() }?.let(::File)
+            ?.takeIf { it.isFile && it.canRead() && it.length() > 0L }
+        if (directFile != null) {
+            return MediaItem.fromUri(Uri.fromFile(directFile))
+        }
+
+        val rawUri = song.contentUriString
+        if (rawUri.isBlank()) return null
+        if (rawUri.startsWith("/")) {
+            val rawFile = File(rawUri)
+            if (rawFile.isFile && rawFile.canRead() && rawFile.length() > 0L) {
+                return MediaItem.fromUri(Uri.fromFile(rawFile))
+            }
+        }
+
+        val uri = runCatching { rawUri.toUri() }.getOrNull() ?: return null
+        return when (uri.scheme?.lowercase(Locale.ROOT)) {
+            "file", "content" -> MediaItem.fromUri(uri)
+            else -> null
+        }
+    }
+
+    private fun outputFileFor(songId: String, requestId: String): File {
+        val dir = File(application.cacheDir, "watch_transfer")
+        return File(dir, "${songId}_$requestId.m4a")
+    }
+
+    companion object {
+        /** Also used by [WatchPlaylistTransferEstimator] to size-estimate songs that will be transcoded. */
+        const val TARGET_BITRATE_BPS = 128_000
+
+        /**
+         * Container mime type of [transcodeIfNeeded]'s output file (an .m4a produced by
+         * [Transformer]'s default muxer) — used by callers reporting [WatchAudioOverride][
+         * PhoneDirectWatchTransferCoordinator.WatchAudioOverride] metadata to the watch.
+         */
+        const val TRANSCODED_OUTPUT_MIME_TYPE = "audio/mp4"
+
+        private const val TAG = "WatchAudioTranscoder"
+        private const val MAX_PASSTHROUGH_BITRATE_BPS = 256_000
+        private const val PROGRESS_POLL_INTERVAL_MS = 250L
+        private val PASSTHROUGH_MIME_TYPES = setOf(
+            "audio/mpeg",
+            "audio/mp4",
+            "audio/aac",
+            "audio/mp4a-latm",
+            "audio/ogg",
+            "audio/opus",
+        )
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoder.kt
@@ -1,6 +1,7 @@
 package com.theveloper.pixelplay.data.service.wear
 
 import android.app.Application
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
@@ -14,11 +15,13 @@ import androidx.media3.transformer.ExportResult
 import androidx.media3.transformer.ProgressHolder
 import androidx.media3.transformer.Transformer
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.di.IoDispatcher
 import com.theveloper.pixelplay.di.MainDispatcher
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 import java.io.File
 import java.util.Locale
@@ -43,6 +46,7 @@ import kotlin.coroutines.resume
 class WatchAudioTranscoder @Inject constructor(
     private val application: Application,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
     sealed class TranscodeResult {
@@ -52,15 +56,48 @@ class WatchAudioTranscoder @Inject constructor(
         data class Failed(val error: Throwable) : TranscodeResult()
     }
 
-    /** Pure decision function, kept separate from the actual encode so it's cheap to unit test. */
-    fun requiresTranscoding(song: Song): Boolean {
-        val mimeType = song.mimeType?.lowercase(Locale.ROOT)
-        val bitrate = song.bitrate
-        val isPassthroughEligible = mimeType != null &&
-            PASSTHROUGH_MIME_TYPES.contains(mimeType) &&
-            bitrate != null &&
-            bitrate <= MAX_PASSTHROUGH_BITRATE_BPS
+    /**
+     * Pure decision function, kept separate from the actual encode so it's cheap to unit test —
+     * and free of I/O, since [WatchPlaylistTransferEstimator] calls it once per song straight
+     * from composition to size the confirmation sheet.
+     *
+     * Uses only the bitrate the library already knows. That's frequently null (a normal
+     * MediaStore scan doesn't read per-file bitrate — only `SyncWorker`'s deep scan does), and an
+     * unknown bitrate is treated as "not eligible" here purely because this overload has no way
+     * to find out; [transcodeIfNeeded] probes the file itself before deciding, so a null here
+     * doesn't condemn the song to a needless re-encode.
+     */
+    fun requiresTranscoding(song: Song): Boolean =
+        requiresTranscoding(song.mimeType, song.bitrate?.takeIf { it > 0 })
+
+    internal fun requiresTranscoding(mimeType: String?, bitrateBps: Int?): Boolean {
+        val normalizedMimeType = mimeType?.lowercase(Locale.ROOT)
+        val isPassthroughEligible = normalizedMimeType != null &&
+            PASSTHROUGH_MIME_TYPES.contains(normalizedMimeType) &&
+            bitrateBps != null &&
+            bitrateBps <= MAX_PASSTHROUGH_BITRATE_BPS
         return !isPassthroughEligible
+    }
+
+    /**
+     * Bitrate to assume when sizing a transfer up front, without touching the file — see
+     * [WatchPlaylistTransferEstimator].
+     *
+     * A lossy source with no known bitrate is the common case for a plain MediaStore-scanned
+     * library, and [transcodeIfNeeded] will probe it and most likely send it through untouched at
+     * whatever its real bitrate is. Assuming [TARGET_BITRATE_BPS] for those would systematically
+     * undershoot the estimate; [ASSUMED_UNKNOWN_LOSSY_BITRATE_BPS] sits between the typical real
+     * value and the passthrough ceiling instead.
+     */
+    fun estimatedTransferBitrateBps(song: Song): Int {
+        val knownBitrate = song.bitrate?.takeIf { it > 0 }
+        val isPassthroughMimeType = song.mimeType?.lowercase(Locale.ROOT)
+            ?.let(PASSTHROUGH_MIME_TYPES::contains) == true
+        return when {
+            knownBitrate == null && isPassthroughMimeType -> ASSUMED_UNKNOWN_LOSSY_BITRATE_BPS
+            requiresTranscoding(song.mimeType, knownBitrate) -> TARGET_BITRATE_BPS
+            else -> knownBitrate ?: TARGET_BITRATE_BPS
+        }
     }
 
     /**
@@ -73,7 +110,7 @@ class WatchAudioTranscoder @Inject constructor(
         requestId: String,
         onProgress: (Float) -> Unit = {},
     ): TranscodeResult {
-        if (!requiresTranscoding(song)) return TranscodeResult.Passthrough
+        if (!requiresTranscoding(song.mimeType, resolveBitrateBps(song))) return TranscodeResult.Passthrough
 
         val inputMediaItem = buildInputMediaItem(song)
             ?: return TranscodeResult.Failed(IllegalStateException("No readable local audio source for songId=${song.id}"))
@@ -82,6 +119,40 @@ class WatchAudioTranscoder @Inject constructor(
         outputFile.parentFile?.mkdirs()
 
         return runTransform(inputMediaItem, outputFile, onProgress)
+    }
+
+    /**
+     * The library's bitrate for [song] when the scan captured one, otherwise read from the file
+     * itself. Without this probe every song in a plainly-scanned library looks like "unknown
+     * bitrate" and gets re-encoded to [TARGET_BITRATE_BPS] — quality lost on an already-lossy
+     * source, and minutes of needless CPU per playlist — because only `SyncWorker`'s deep scan
+     * populates `Song.bitrate` at all.
+     *
+     * Never fails a transfer: anything unreadable falls back to null, which keeps the old
+     * conservative "re-encode it" answer.
+     */
+    private suspend fun resolveBitrateBps(song: Song): Int? {
+        song.bitrate?.takeIf { it > 0 }?.let { return it }
+        return withContext(ioDispatcher) { probeBitrateBps(song) }
+    }
+
+    private fun probeBitrateBps(song: Song): Int? {
+        val source = buildInputMediaItem(song)?.localConfiguration?.uri ?: return null
+        val retriever = MediaMetadataRetriever()
+        return try {
+            when (source.scheme?.lowercase(Locale.ROOT)) {
+                "content" -> retriever.setDataSource(application, source)
+                else -> retriever.setDataSource(source.path ?: return null)
+            }
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)
+                ?.toIntOrNull()
+                ?.takeIf { it > 0 }
+        } catch (error: Exception) {
+            Timber.tag(TAG).w(error, "Failed to probe bitrate for songId=%s", song.id)
+            null
+        } finally {
+            runCatching { retriever.release() }
+        }
     }
 
     fun cleanup(result: TranscodeResult) {
@@ -98,7 +169,25 @@ class WatchAudioTranscoder @Inject constructor(
         outputFile: File,
         onProgress: (Float) -> Unit,
     ): TranscodeResult = withContext(mainDispatcher) {
-        suspendCancellableCoroutine { continuation ->
+        // Every other await in this pipeline has a backstop; this one used to have none, and it
+        // resumes only from Transformer's own onCompleted/onError. A wedged encoder (a malformed
+        // or DRM'd source) therefore stalled the whole batch forever, with the notification frozen
+        // at its last value and a cancel unable to take effect until the transcode returned.
+        // Timing out here rather than at the call site keeps the cancellation — and so
+        // transformer.cancel() via invokeOnCancellation — on the Looper thread Media3 requires.
+        withTimeoutOrNull(TRANSCODE_TIMEOUT_MS) {
+            runTransformUntilTerminal(inputMediaItem, outputFile, onProgress)
+        } ?: TranscodeResult.Failed(
+            IllegalStateException("Transcode timed out after ${TRANSCODE_TIMEOUT_MS}ms")
+        )
+    }
+
+    private suspend fun runTransformUntilTerminal(
+        inputMediaItem: MediaItem,
+        outputFile: File,
+        onProgress: (Float) -> Unit,
+    ): TranscodeResult {
+        return suspendCancellableCoroutine { continuation ->
             val encoderFactory = DefaultEncoderFactory.Builder(application)
                 .setRequestedAudioEncoderSettings(
                     AudioEncoderSettings.Builder().setBitrate(TARGET_BITRATE_BPS).build()
@@ -204,6 +293,14 @@ class WatchAudioTranscoder @Inject constructor(
         private const val TAG = "WatchAudioTranscoder"
         private const val MAX_PASSTHROUGH_BITRATE_BPS = 256_000
         private const val PROGRESS_POLL_INTERVAL_MS = 250L
+
+        /** See [estimatedTransferBitrateBps] — a mid-range guess for an unprobed lossy source. */
+        private const val ASSUMED_UNKNOWN_LOSSY_BITRATE_BPS = 192_000
+
+        // Generous relative to a real encode (a few seconds for a normal song on a modern phone,
+        // and Media3 reports progress throughout): this only exists to unstick an encoder that
+        // has stopped making progress entirely, not to cap a slow-but-working one.
+        private const val TRANSCODE_TIMEOUT_MS = 180_000L
         private val PASSTHROUGH_MIME_TYPES = setOf(
             "audio/mpeg",
             "audio/mp4",

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimator.kt
@@ -1,0 +1,63 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import androidx.media3.common.util.UnstableApi
+import com.theveloper.pixelplay.data.model.Song
+
+/**
+ * Aggregate size/time estimate shown on the send-to-watch confirmation sheet, computed only over
+ * the songs that still need to be transferred (already-on-watch songs are skipped by the dedupe
+ * in [PlaylistWatchTransferCoordinator], so they don't cost bandwidth or storage).
+ */
+data class WatchPlaylistTransferEstimate(
+    val totalSongCount: Int,
+    val pendingSongCount: Int,
+    val estimatedBytes: Long,
+    val estimatedTransferSeconds: Long,
+)
+
+/**
+ * Pure size/time heuristics for the whole-playlist watch transfer confirmation UI. Kept separate
+ * from [WatchAudioTranscoder] (which does the real encode) so it stays cheap to unit test.
+ */
+@UnstableApi
+object WatchPlaylistTransferEstimator {
+
+    /**
+     * Assumed throughput for the single Bluetooth channel used for the transfer (phase 1 — no
+     * Wi-Fi transport yet). This is the Wearable Data Layer ChannelClient rate, not raw Bluetooth
+     * bandwidth, and is deliberately conservative: an estimate that undershoots the real time
+     * erodes trust in the confirmation sheet more than one that's a bit pessimistic. Needs
+     * re-measuring against a real phone+watch pair once device testing resumes — see §R-04 of the
+     * Wear OS guide for the documented range (~50–150 KB/s) this sits below on purpose.
+     */
+    private const val ASSUMED_TRANSFER_RATE_BYTES_PER_SEC = 40_000L
+
+    fun estimateBytesForSong(song: Song, transcoder: WatchAudioTranscoder): Long {
+        val effectiveBitrateBps = if (transcoder.requiresTranscoding(song)) {
+            WatchAudioTranscoder.TARGET_BITRATE_BPS
+        } else {
+            song.bitrate ?: WatchAudioTranscoder.TARGET_BITRATE_BPS
+        }
+        val durationSeconds = song.duration / 1000.0
+        return (durationSeconds * effectiveBitrateBps / 8.0).toLong().coerceAtLeast(0L)
+    }
+
+    fun estimate(
+        allSongs: List<Song>,
+        pendingSongs: List<Song>,
+        transcoder: WatchAudioTranscoder,
+    ): WatchPlaylistTransferEstimate {
+        val totalBytes = pendingSongs.sumOf { estimateBytesForSong(it, transcoder) }
+        return WatchPlaylistTransferEstimate(
+            totalSongCount = allSongs.size,
+            pendingSongCount = pendingSongs.size,
+            estimatedBytes = totalBytes,
+            estimatedTransferSeconds = estimateTransferSeconds(totalBytes),
+        )
+    }
+
+    private fun estimateTransferSeconds(totalBytes: Long): Long {
+        if (totalBytes <= 0L) return 0L
+        return (totalBytes / ASSUMED_TRANSFER_RATE_BYTES_PER_SEC).coerceAtLeast(1L)
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimator.kt
@@ -33,11 +33,10 @@ object WatchPlaylistTransferEstimator {
     private const val ASSUMED_TRANSFER_RATE_BYTES_PER_SEC = 40_000L
 
     fun estimateBytesForSong(song: Song, transcoder: WatchAudioTranscoder): Long {
-        val effectiveBitrateBps = if (transcoder.requiresTranscoding(song)) {
-            WatchAudioTranscoder.TARGET_BITRATE_BPS
-        } else {
-            song.bitrate ?: WatchAudioTranscoder.TARGET_BITRATE_BPS
-        }
+        // Delegated so the "what will this song actually weigh on the wire" rule lives in one
+        // place: the transcoder probes an unknown bitrate before deciding, and only it knows what
+        // that probe is likely to find (see WatchAudioTranscoder.estimatedTransferBitrateBps).
+        val effectiveBitrateBps = transcoder.estimatedTransferBitrateBps(song)
         val durationSeconds = song.duration / 1000.0
         return (durationSeconds * effectiveBitrateBps / 8.0).toLong().coerceAtLeast(0L)
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchTransferForegroundService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchTransferForegroundService.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -43,7 +44,10 @@ class WatchTransferForegroundService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val notification = buildNotification(transferStateStore.transfers.value.values.toList())
+        val notification = buildNotification(
+            transferStateStore.transfers.value.values.toList(),
+            transferStateStore.batchTransfers.value.values.toList(),
+        )
         if (!hasStartedForeground) {
             startInForeground(notification)
         } else {
@@ -63,21 +67,24 @@ class WatchTransferForegroundService : Service() {
     private fun observeTransfers() {
         transferObserverJob?.cancel()
         transferObserverJob = serviceScope.launch {
-            transferStateStore.transfers.collect { transfers ->
-                val states = transfers.values.toList()
-                if (states.isEmpty()) {
-                    stopForegroundCompat()
-                    stopSelf()
-                    return@collect
-                }
+            combine(
+                transferStateStore.transfers,
+                transferStateStore.batchTransfers,
+            ) { transfers, batches -> transfers.values.toList() to batches.values.toList() }
+                .collect { (transferStates, batchStates) ->
+                    if (transferStates.isEmpty() && batchStates.isEmpty()) {
+                        stopForegroundCompat()
+                        stopSelf()
+                        return@collect
+                    }
 
-                val notification = buildNotification(states)
-                if (!hasStartedForeground) {
-                    startInForeground(notification)
-                } else {
-                    notificationManager().notify(NOTIFICATION_ID, notification)
+                    val notification = buildNotification(transferStates, batchStates)
+                    if (!hasStartedForeground) {
+                        startInForeground(notification)
+                    } else {
+                        notificationManager().notify(NOTIFICATION_ID, notification)
+                    }
                 }
-            }
         }
     }
 
@@ -110,7 +117,85 @@ class WatchTransferForegroundService : Service() {
         hasStartedForeground = false
     }
 
-    private fun buildNotification(transfers: List<PhoneWatchTransferState>): Notification {
+    /**
+     * A playlist batch, when one is active or just finished, takes priority over any concurrent
+     * lone single-song transfer (e.g. from the song info sheet) — it's the longer-running, more
+     * significant operation, and showing both at once would make the notification unreadable.
+     */
+    private fun buildNotification(
+        transfers: List<PhoneWatchTransferState>,
+        batches: List<PhoneWatchBatchTransferState>,
+    ): Notification {
+        val selectedBatch = batches.firstOrNull { it.status == WearTransferProgress.STATUS_TRANSFERRING }
+            ?: batches.maxByOrNull { it.updatedAtMillis }
+        return if (selectedBatch != null) {
+            buildBatchNotification(selectedBatch)
+        } else {
+            buildSongNotification(transfers)
+        }
+    }
+
+    private fun buildBatchNotification(batch: PhoneWatchBatchTransferState): Notification {
+        val isOngoing = batch.status == WearTransferProgress.STATUS_TRANSFERRING
+        val title = when (batch.status) {
+            WearTransferProgress.STATUS_TRANSFERRING ->
+                getString(R.string.watch_transfer_status_sending_playlist_to_watch, batch.playlistName)
+            WearTransferProgress.STATUS_COMPLETED -> getString(R.string.watch_transfer_status_complete_service)
+            WearTransferProgress.STATUS_FAILED -> getString(R.string.watch_transfer_status_failed_service)
+            WearTransferProgress.STATUS_CANCELLED -> getString(R.string.watch_transfer_status_cancelled_service)
+            else -> getString(R.string.watch_transfer_status_preparing_service)
+        }
+        val contentText = getString(
+            R.string.watch_transfer_batch_progress,
+            batch.processedSongCount,
+            batch.totalSongCount,
+        )
+        val overallProgress = if (batch.totalSongCount > 0) {
+            ((batch.processedSongCount + batch.currentSongProgress) / batch.totalSongCount.toFloat())
+        } else {
+            0f
+        }.coerceIn(0f, 1f)
+        val progressPercent = (overallProgress * 100f).toInt().coerceIn(0, 100)
+
+        val builder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.monochrome_player)
+            .setContentTitle(title)
+            .setContentText(contentText)
+            .setContentIntent(createOpenAppPendingIntent())
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOnlyAlertOnce(true)
+            .setSilent(true)
+            .setOngoing(isOngoing)
+            .setShowWhen(false)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+
+        if (isOngoing) {
+            builder.setProgress(100, progressPercent, false)
+        } else {
+            builder.setProgress(0, 0, false)
+        }
+
+        val detailText = buildBatchDetailedText(batch)
+        if (detailText.isNotBlank()) {
+            builder.setStyle(NotificationCompat.BigTextStyle().bigText(detailText))
+        }
+
+        return builder.build()
+    }
+
+    private fun buildBatchDetailedText(batch: PhoneWatchBatchTransferState): String {
+        val songLine = batch.currentSongTitle.ifBlank { null }
+        val failedLine = if (batch.failedSongCount > 0) {
+            getString(R.string.watch_transfer_batch_failed_count, batch.failedSongCount)
+        } else {
+            null
+        }
+        val errorLine = batch.errorMessage?.takeIf { it.isNotBlank() }
+        return listOfNotNull(songLine, failedLine, errorLine).joinToString(separator = "\n")
+    }
+
+    private fun buildSongNotification(transfers: List<PhoneWatchTransferState>): Notification {
         val activeTransfers = transfers.filter { it.status == WearTransferProgress.STATUS_TRANSFERRING }
         val selectedTransfer = activeTransfers.maxByOrNull { it.updatedAtMillis }
             ?: transfers.maxByOrNull { it.updatedAtMillis }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
@@ -562,7 +562,12 @@ class WearCommandReceiver : WearableListenerService() {
             status = progress.status,
             error = progress.error,
         )
-        if (progress.status == WearTransferProgress.STATUS_COMPLETED) {
+        // A duplicate rejection is just as good a confirmation that the song is on this watch as
+        // a completion is — it's the watch saying it already has it — and recording it keeps the
+        // rest of the transfer (and the next "update on watch") from offering that song again.
+        val confirmsSongOnWatch = progress.status == WearTransferProgress.STATUS_COMPLETED ||
+            progress.error == WearTransferProgress.ERROR_ALREADY_ON_WATCH
+        if (confirmsSongOnWatch) {
             transferStateStore.markSongPresentOnWatch(
                 nodeId = messageEvent.sourceNodeId,
                 songId = progress.songId,

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
@@ -25,6 +25,7 @@ import com.theveloper.pixelplay.shared.WearBrowseRequest
 import com.theveloper.pixelplay.shared.WearBrowseResponse
 import com.theveloper.pixelplay.shared.WearDataPaths
 import com.theveloper.pixelplay.shared.WearLibraryItem
+import com.theveloper.pixelplay.shared.WearLibraryState
 import com.theveloper.pixelplay.shared.WearPlaybackCommand
 import com.theveloper.pixelplay.shared.WearPlaylistSyncAck
 import com.theveloper.pixelplay.shared.WearTransferMetadata
@@ -100,6 +101,7 @@ class WearCommandReceiver : WearableListenerService() {
             WearDataPaths.TRANSFER_CANCEL -> handleTransferCancel(messageEvent)
             WearDataPaths.PLAYLIST_SYNC_ACK -> handlePlaylistSyncAck(messageEvent)
             WearDataPaths.TRANSFER_PROGRESS -> handleTransferOutcomeFromWatch(messageEvent)
+            WearDataPaths.WATCH_LIBRARY_STATE -> handleWatchLibraryState(messageEvent)
             else -> Timber.tag(TAG).w("Unknown message path: ${messageEvent.path}")
         }
     }
@@ -546,6 +548,38 @@ class WearCommandReceiver : WearableListenerService() {
      * save-to-library transfer past [WearTransferProgress.STATUS_AWAITING_WATCH_ACK]: the phone
      * no longer assumes success just because it finished streaming bytes.
      */
+    /**
+     * The watch's answer to [WearDataPaths.WATCH_LIBRARY_QUERY] — the only thing that tells this
+     * phone what the watch *actually* holds, as opposed to what this phone remembers sending it.
+     *
+     * Without it the phone's picture only ever grows, from its own completed transfers, and never
+     * corrects itself: songs deleted on the watch, or a watch app reinstalled (which wipes its
+     * library outright), still look present here — so a playlist would offer "update" and skip
+     * songs the watch no longer has. It also gates
+     * [PhoneWatchTransferStateStore.isWatchLibraryResolved], which
+     * [PlaylistWatchTransferCoordinator.resumePersistedBatchIfNeeded] waits on before resuming.
+     */
+    private fun handleWatchLibraryState(messageEvent: MessageEvent) {
+        val libraryJson = String(messageEvent.data, Charsets.UTF_8)
+        val libraryState = try {
+            json.decodeFromString<WearLibraryState>(libraryJson)
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Failed to parse watch library state")
+            return
+        }
+        Timber.tag(TAG).d(
+            "Watch library state from node=%s: %d songs, %d playlists",
+            messageEvent.sourceNodeId,
+            libraryState.songIds.size,
+            libraryState.playlistIds.size,
+        )
+        transferStateStore.updateWatchLibrary(
+            nodeId = messageEvent.sourceNodeId,
+            songIds = libraryState.songIds.toSet(),
+            playlistIds = libraryState.playlistIds.toSet(),
+        )
+    }
+
     private fun handleTransferOutcomeFromWatch(messageEvent: MessageEvent) {
         val progressJson = String(messageEvent.data, Charsets.UTF_8)
         val progress = try {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
@@ -26,6 +26,7 @@ import com.theveloper.pixelplay.shared.WearBrowseResponse
 import com.theveloper.pixelplay.shared.WearDataPaths
 import com.theveloper.pixelplay.shared.WearLibraryItem
 import com.theveloper.pixelplay.shared.WearPlaybackCommand
+import com.theveloper.pixelplay.shared.WearPlaylistSyncAck
 import com.theveloper.pixelplay.shared.WearTransferMetadata
 import com.theveloper.pixelplay.shared.WearTransferProgress
 import com.theveloper.pixelplay.shared.WearTransferRequest
@@ -97,6 +98,8 @@ class WearCommandReceiver : WearableListenerService() {
             WearDataPaths.BROWSE_REQUEST -> handleBrowseRequest(messageEvent)
             WearDataPaths.TRANSFER_REQUEST -> handleTransferRequest(messageEvent)
             WearDataPaths.TRANSFER_CANCEL -> handleTransferCancel(messageEvent)
+            WearDataPaths.PLAYLIST_SYNC_ACK -> handlePlaylistSyncAck(messageEvent)
+            WearDataPaths.TRANSFER_PROGRESS -> handleTransferOutcomeFromWatch(messageEvent)
             else -> Timber.tag(TAG).w("Unknown message path: ${messageEvent.path}")
         }
     }
@@ -522,6 +525,49 @@ class WearCommandReceiver : WearableListenerService() {
             startPositionMs = request.startPositionMs,
             autoPlay = request.autoPlay,
         )
+    }
+
+    private fun handlePlaylistSyncAck(messageEvent: MessageEvent) {
+        val ackJson = String(messageEvent.data, Charsets.UTF_8)
+        val ack = try {
+            json.decodeFromString<WearPlaylistSyncAck>(ackJson)
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Failed to parse playlist sync ack")
+            return
+        }
+        transferStateStore.onPlaylistSyncAckReceived(ack)
+    }
+
+    /**
+     * The watch's real outcome for a transfer it received — metadata acked, the file actually
+     * written and playable, or a genuine failure — sent over the same [WearDataPaths]
+     * .TRANSFER_PROGRESS path this receiver's own [PhoneDirectWatchTransferCoordinator] uses to
+     * push its send-side progress to the watch. This is now the only thing that advances a
+     * save-to-library transfer past [WearTransferProgress.STATUS_AWAITING_WATCH_ACK]: the phone
+     * no longer assumes success just because it finished streaming bytes.
+     */
+    private fun handleTransferOutcomeFromWatch(messageEvent: MessageEvent) {
+        val progressJson = String(messageEvent.data, Charsets.UTF_8)
+        val progress = try {
+            json.decodeFromString<WearTransferProgress>(progressJson)
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Failed to parse transfer outcome from watch")
+            return
+        }
+        transferStateStore.markProgress(
+            requestId = progress.requestId,
+            songId = progress.songId,
+            bytesTransferred = progress.bytesTransferred,
+            totalBytes = progress.totalBytes,
+            status = progress.status,
+            error = progress.error,
+        )
+        if (progress.status == WearTransferProgress.STATUS_COMPLETED) {
+            transferStateStore.markSongPresentOnWatch(
+                nodeId = messageEvent.sourceNodeId,
+                songId = progress.songId,
+            )
+        }
     }
 
     private fun handleTransferCancel(messageEvent: MessageEvent) {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearPerformanceSettingsPublisher.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearPerformanceSettingsPublisher.kt
@@ -1,0 +1,55 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import android.app.Application
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.theveloper.pixelplay.shared.WearDataPaths
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Publishes the watch performance toggles (Settings -> "Watch") to the Wear Data Layer as a
+ * DataItem, not a `MessageClient` message — mirrors [WearStatePublisher]'s `PLAYER_STATE`
+ * publishing. A `MessageClient` send only confirms local hand-off, not that the watch received
+ * it (the exact bug fixed for playlist sync — see [WearDataPaths.PLAYLIST_SYNC_ACK]'s doc). A
+ * DataItem instead syncs durably: if the watch is mid-reconnect when this publishes, it still
+ * gets the update once it's back, with no ack/retry machinery needed on our side for that.
+ */
+@Singleton
+class WearPerformanceSettingsPublisher @Inject constructor(
+    private val application: Application,
+) {
+    private val dataClient by lazy { Wearable.getDataClient(application) }
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun publish(showAlbumArt: Boolean, dynamicColorTheming: Boolean, playButtonAnimation: Boolean) {
+        scope.launch {
+            try {
+                val request = PutDataMapRequest.create(WearDataPaths.WEAR_PERFORMANCE_SETTINGS).apply {
+                    dataMap.putBoolean(WearDataPaths.KEY_SHOW_ALBUM_ART, showAlbumArt)
+                    dataMap.putBoolean(WearDataPaths.KEY_DYNAMIC_COLOR_THEMING, dynamicColorTheming)
+                    dataMap.putBoolean(WearDataPaths.KEY_PLAY_BUTTON_ANIMATION, playButtonAnimation)
+                }.asPutDataRequest().setUrgent()
+
+                dataClient.putDataItem(request)
+                Timber.tag(TAG).d(
+                    "Published performance settings: albumArt=%s dynamicColor=%s playButtonAnim=%s",
+                    showAlbumArt,
+                    dynamicColorTheming,
+                    playButtonAnimation,
+                )
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Failed to publish performance settings to watch")
+            }
+        }
+    }
+
+    private companion object {
+        const val TAG = "WearPerfSettingsPub"
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearPhoneTransferSender.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearPhoneTransferSender.kt
@@ -42,6 +42,31 @@ class WearPhoneTransferSender @Inject constructor(
         }
     }
 
+    /**
+     * Distinct from [isPixelPlayWatchAvailable]: `FILTER_ALL` returns every node that has ever
+     * advertised the PixelPlay capability, reachable or not, instead of only ones reachable right
+     * now — the signal for "has the user ever paired a watch with PixelPlay installed at all",
+     * used to hide watch-related UI entirely for someone who never has, as opposed to showing it
+     * disabled/"not connected" for a paired watch that's just out of range at the moment.
+     */
+    suspend fun refreshWatchPairingState(): Boolean {
+        return runCatching {
+            val capability = capabilityClient.getCapability(
+                WearCapabilities.PIXELPLAY_WEAR_APP,
+                CapabilityClient.FILTER_ALL,
+            ).await()
+            val paired = capability.nodes.isNotEmpty()
+            transferStateStore.setAnyWatchPaired(paired)
+            paired
+        }.getOrElse { error ->
+            Timber.tag(TAG).w(error, "Failed checking whether any watch is paired")
+            // Deliberately don't clear transferStateStore's flag on failure (unlike
+            // isPixelPlayWatchAvailable's reachability reset): a transient error here shouldn't
+            // hide UI that a previous successful check already confirmed should be visible.
+            transferStateStore.isAnyWatchPaired.value
+        }
+    }
+
     suspend fun refreshWatchLibraryState(): Result<Unit> {
         return runCatching {
             val capability = capabilityClient.getCapability(

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -1,5 +1,6 @@
 package com.theveloper.pixelplay.di
 
+import android.app.Application
 import android.content.Context
 import androidx.annotation.OptIn
 import androidx.datastore.core.DataStore
@@ -15,6 +16,9 @@ import androidx.work.WorkManager
 import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.Wearable
 import com.theveloper.pixelplay.BuildConfig
 import com.theveloper.pixelplay.PixelPlayApplication
 import com.theveloper.pixelplay.data.database.AlbumArtThemeDao
@@ -56,6 +60,7 @@ import kotlinx.serialization.json.Json
 import javax.inject.Qualifier
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import okhttp3.OkHttpClient
@@ -112,6 +117,28 @@ object AppModule {
     fun provideAppCoroutineScope(): CoroutineScope {
         return CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
+
+    @Provides
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @MainDispatcher
+    fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+    // Injected (unlike the rest of the wear/ package, which resolves these via
+    // Wearable.getXClient(application) internally) so PlaylistWatchTransferCoordinator can be
+    // constructed with fakes in tests — CapabilityClient/MessageClient are non-final abstract
+    // classes, so MockK can subclass them directly with no inline-mocking agent involved.
+    @Singleton
+    @Provides
+    fun provideCapabilityClient(application: Application): CapabilityClient =
+        Wearable.getCapabilityClient(application)
+
+    @Singleton
+    @Provides
+    fun provideMessageClient(application: Application): MessageClient =
+        Wearable.getMessageClient(application)
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/theveloper/pixelplay/di/Qualifiers.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/Qualifiers.kt
@@ -29,3 +29,21 @@ annotation class BackupGson
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class AppScope
+
+/**
+ * Qualifier for the IO [kotlinx.coroutines.CoroutineDispatcher]. Injected rather than referenced
+ * as `Dispatchers.IO` directly so tests can substitute a `TestDispatcher` (implements
+ * `AND-CONC-03`). Most of this codebase predates this convention and still references
+ * `Dispatchers.IO` directly — only use this qualifier in new code.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+/**
+ * Qualifier for the Main [kotlinx.coroutines.CoroutineDispatcher]. Same rationale as
+ * [IoDispatcher] — new code only.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class MainDispatcher

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongInfoBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongInfoBottomSheet.kt
@@ -158,6 +158,7 @@ fun SongInfoBottomSheet(
     val audioMeta by songInfoViewModel.audioMeta.collectAsStateWithLifecycle()
     val resolvedArtists by songInfoViewModel.resolvedArtists.collectAsStateWithLifecycle()
     val isPixelPlayWatchAvailable by songInfoViewModel.isPixelPlayWatchAvailable.collectAsStateWithLifecycle()
+    val isAnyWatchPaired by songInfoViewModel.isAnyWatchPaired.collectAsStateWithLifecycle()
     val isWatchAvailabilityResolved by songInfoViewModel.isWatchAvailabilityResolved.collectAsStateWithLifecycle()
     val isSendingToWatch by songInfoViewModel.isSendingToWatch.collectAsStateWithLifecycle()
     val watchTransfers by songInfoViewModel.watchTransfers.collectAsStateWithLifecycle()
@@ -281,21 +282,29 @@ fun SongInfoBottomSheet(
     val shouldOfferWatchTransfer = remember(
         canSendToWatch,
         currentSongTransfer,
+        isAnyWatchPaired,
         isPixelPlayWatchAvailable,
         isSongSavedOnWatch,
         isWatchAvailabilityResolved,
     ) {
         currentSongTransfer == null &&
                 canSendToWatch &&
+                isAnyWatchPaired &&
                 isWatchAvailabilityResolved &&
                 isPixelPlayWatchAvailable &&
                 !isSongSavedOnWatch
     }
+    // isAnyWatchPaired gates this too — otherwise this "checking watch…" state would flash for
+    // every song info sheet even on a phone that's never paired a watch at all, since
+    // isWatchAvailabilityResolved only flips true after the (irrelevant, in that case) reachability
+    // check finishes.
     val shouldShowWatchTransferLoading = remember(
         canSendToWatch,
+        isAnyWatchPaired,
         isWatchAvailabilityResolved,
     ) {
         canSendToWatch &&
+                isAnyWatchPaired &&
                 !isWatchAvailabilityResolved
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/model/SettingsCategory.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/model/SettingsCategory.kt
@@ -73,6 +73,12 @@ enum class SettingsCategory(
         subtitleRes = R.string.settings_category_device_capabilities_subtitle,
         icon = Icons.Rounded.DeveloperBoard // Placeholder, maybe Memory or SettingsInputComponent
     ),
+    WEAR_OS(
+        id = "wear_os",
+        titleRes = R.string.settings_category_wear_title,
+        subtitleRes = R.string.settings_category_wear_subtitle,
+        iconRes = R.drawable.rounded_watch_arrow_down_24
+    ),
     ABOUT(
         id = "about",
         titleRes = R.string.settings_category_about_title,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -245,6 +245,7 @@ import com.theveloper.pixelplay.presentation.components.ExpressiveScrollBar
 import com.theveloper.pixelplay.ui.theme.LocalShowScrollbar
 import com.theveloper.pixelplay.presentation.components.LibrarySortBottomSheet
 import com.theveloper.pixelplay.presentation.components.subcomps.EnhancedSongListItem
+import com.theveloper.pixelplay.data.service.wear.PhoneWatchBatchTransferState
 import com.theveloper.pixelplay.data.service.wear.PhoneWatchTransferState
 import com.theveloper.pixelplay.shared.WearTransferProgress
 import java.io.File
@@ -385,6 +386,141 @@ private fun WatchTransferProgressDialog(
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun WatchPlaylistBatchProgressDialog(
+    batch: PhoneWatchBatchTransferState,
+    onDismiss: () -> Unit,
+    onCancelTransfer: () -> Unit,
+) {
+    val rawProgress = if (batch.totalSongCount > 0) {
+        ((batch.processedSongCount + batch.currentSongProgress) / batch.totalSongCount.toFloat())
+    } else {
+        0f
+    }.coerceIn(0f, 1f)
+    val animatedProgress by animateFloatAsState(
+        targetValue = rawProgress,
+        animationSpec = tween(durationMillis = 300),
+        label = "WatchPlaylistBatchProgressDialog"
+    )
+    val progressPercent = (animatedProgress * 100f).toInt().coerceIn(0, 100)
+    val statusText = when (batch.status) {
+        WearTransferProgress.STATUS_TRANSFERRING -> stringResource(R.string.watch_transfer_status_transferring)
+        WearTransferProgress.STATUS_COMPLETED -> stringResource(R.string.watch_transfer_status_completed)
+        WearTransferProgress.STATUS_FAILED -> stringResource(R.string.watch_transfer_status_failed)
+        WearTransferProgress.STATUS_CANCELLED -> stringResource(R.string.watch_transfer_status_cancelled)
+        else -> stringResource(R.string.watch_transfer_status_preparing)
+    }
+    val songsText = stringResource(
+        R.string.watch_transfer_batch_progress,
+        batch.processedSongCount,
+        batch.totalSongCount,
+    )
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
+        )
+    ) {
+        Surface(
+            shape = RoundedCornerShape(28.dp),
+            tonalElevation = 6.dp,
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.watch_transfer_dialog_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Box(
+                    modifier = Modifier
+                        .size(96.dp)
+                        .padding(vertical = 20.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    LoadingIndicator(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .scale(1.84f),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        text = stringResource(R.string.common_percentage_text, progressPercent),
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            fontSize = MaterialTheme.typography.labelLarge.fontSize * 1.4f
+                        ),
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+                LinearWavyProgressIndicator(
+                    progress = { animatedProgress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(50)),
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                )
+                Text(
+                    text = batch.playlistName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center
+                )
+                if (batch.status == WearTransferProgress.STATUS_TRANSFERRING && batch.currentSongTitle.isNotBlank()) {
+                    Text(
+                        text = stringResource(R.string.watch_transfer_current_song, batch.currentSongTitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.watch_transfer_bullet_step, statusText, songsText),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+                if (batch.failedSongCount > 0) {
+                    Text(
+                        text = stringResource(R.string.watch_transfer_batch_failed_count, batch.failedSongCount),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center
+                    )
+                }
+                if (batch.status == WearTransferProgress.STATUS_TRANSFERRING) {
+                    Button(
+                        modifier = Modifier.padding(top = 4.dp),
+                        onClick = onCancelTransfer,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError
+                        )
+                    ) {
+                        Text(text = stringResource(R.string.watch_transfer_action_cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                }
+            }
+        }
+    }
+}
+
 private data class LibraryScreenPlayerProjection(
     val currentFolder: MusicFolder? = null,
     val folderSourceRootPath: String = "",
@@ -486,6 +622,11 @@ fun LibraryScreen(
     val isSendingToWatch by songInfoBottomSheetViewModel.isSendingToWatch.collectAsStateWithLifecycle()
     val activeWatchTransfer by songInfoBottomSheetViewModel.activeWatchTransfer.collectAsStateWithLifecycle()
     var showWatchTransferDialog by remember { mutableStateOf(false) }
+    // A playlist batch takes priority over a concurrent lone single-song transfer in this badge —
+    // same priority rule as the transfer notification (WatchTransferForegroundService): it's the
+    // longer-running, more significant operation.
+    val activePlaylistBatchTransfer by playlistViewModel.activePlaylistBatchTransfer.collectAsStateWithLifecycle()
+    var showWatchBatchProgressDialog by remember { mutableStateOf(false) }
     val canNavigateBackInFolders by remember(playerViewModel) {
         playerViewModel.playerUiState
             .map { uiState -> uiState.currentFolder != null && uiState.folderBackGestureNavigationEnabled }
@@ -507,6 +648,12 @@ fun LibraryScreen(
 
     var showReorderTabsSheet by remember { mutableStateOf(false) }
     var showTabSwitcherSheet by remember { mutableStateOf(false) }
+
+    LaunchedEffect(activePlaylistBatchTransfer?.batchId) {
+        if (activePlaylistBatchTransfer == null) {
+            showWatchBatchProgressDialog = false
+        }
+    }
 
     LaunchedEffect(activeWatchTransfer?.requestId) {
         if (activeWatchTransfer == null) {
@@ -847,14 +994,15 @@ fun LibraryScreen(
                 TopAppBar(
                     title = {
                         if (isCompactNavigation) {
+                            val isShowingWatchBadge = activePlaylistBatchTransfer != null || isSendingToWatch
                             LibraryNavigationPill(
                                 modifier = Modifier,
                                 title = currentTabTitle,
                                 isExpanded = showTabSwitcherSheet,
-                                showIcon = !isSendingToWatch,
+                                showIcon = !isShowingWatchBadge,
                                 iconRes = currentTab.iconRes(),
                                 pageIndex = pagerState.currentPage,
-                                compressForWatchTransfer = isSendingToWatch,
+                                compressForWatchTransfer = isShowingWatchBadge,
                                 onClick = {
                                     showTabSwitcherSheet = true
                                 },
@@ -873,7 +1021,45 @@ fun LibraryScreen(
                         }
                     },
                     actions = {
-                        if (isSendingToWatch) {
+                        val currentBatch = activePlaylistBatchTransfer
+                        if (currentBatch != null) {
+                            val batchProgress = if (currentBatch.totalSongCount > 0) {
+                                ((currentBatch.processedSongCount + currentBatch.currentSongProgress) / currentBatch.totalSongCount.toFloat())
+                                    .coerceIn(0f, 1f)
+                            } else {
+                                0f
+                            }
+                            val batchPercent = (batchProgress * 100f).toInt().coerceIn(0, 100)
+                            Surface(
+                                modifier = Modifier
+                                    .padding(end = 8.dp)
+                                    .wrapContentWidth()
+                                    .height(40.dp)
+                                    .clip(CircleShape)
+                                    .clickable { showWatchBatchProgressDialog = true },
+                                shape = CircleShape,
+                                color = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .padding(horizontal = 8.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.rounded_watch_arrow_down_24),
+                                        contentDescription = stringResource(R.string.library_cd_watch_transfer),
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                    Text(
+                                        text = stringResource(R.string.common_percentage_text, batchPercent),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                }
+                            }
+                        } else if (isSendingToWatch) {
                             val watchTransferProgress = activeWatchTransfer?.progress ?: 0f
                             val watchTransferPercent = (watchTransferProgress * 100f).toInt().coerceIn(0, 100)
                             Surface(
@@ -1817,6 +2003,19 @@ fun LibraryScreen(
             )
         }
     )
+
+    if (showWatchBatchProgressDialog) {
+        activePlaylistBatchTransfer?.let { currentBatch ->
+            WatchPlaylistBatchProgressDialog(
+                batch = currentBatch,
+                onDismiss = { showWatchBatchProgressDialog = false },
+                onCancelTransfer = {
+                    playlistViewModel.cancelPlaylistTransfer(currentBatch.batchId)
+                    showWatchBatchProgressDialog = false
+                }
+            )
+        }
+    }
 
     if (showWatchTransferDialog && activeWatchTransfer != null) {
         val currentWatchTransfer = activeWatchTransfer!!

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -48,6 +49,7 @@ import androidx.compose.material.icons.filled.MusicOff
 import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.DragIndicator
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Shuffle
@@ -134,6 +136,10 @@ import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
 import com.theveloper.pixelplay.presentation.viewmodel.PlaylistSongsOrderMode
 import com.theveloper.pixelplay.utils.formatSongCount
 import com.theveloper.pixelplay.utils.formatTotalDuration
+import com.theveloper.pixelplay.utils.formatListeningDurationCompact
+import com.theveloper.pixelplay.data.service.wear.PhoneWatchBatchTransferState
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LinearWavyProgressIndicator
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -179,6 +185,9 @@ fun PlaylistDetailScreen(
     val deletePlaylistLabel = stringResource(R.string.playlist_action_delete_playlist)
     val setDefaultTransitionLabel = stringResource(R.string.playlist_action_set_default_transition)
     val exportPlaylistLabel = stringResource(R.string.playlist_action_export_playlist)
+    val sendToWatchLabel = stringResource(R.string.playlist_action_send_to_watch)
+    val updateOnWatchLabel = stringResource(R.string.playlist_action_update_on_watch)
+    val sendToWatchCd = stringResource(R.string.playlist_cd_send_to_watch)
     val deletePlaylistConfirmTitle = stringResource(R.string.playlist_dialog_delete_title)
     val deletePlaylistConfirmBody = stringResource(R.string.playlist_dialog_delete_body)
     val sortSheetTitle = stringResource(R.string.playlist_sort_songs_title)
@@ -192,6 +201,12 @@ fun PlaylistDetailScreen(
         playlistViewModel.loadPlaylistDetails(playlistId)
     }
 
+    // So "Send to Watch" in the options sheet below can be gated on isAnyWatchPaired before the
+    // user ever opens that sheet, not only refreshed reactively once they tap it.
+    LaunchedEffect(Unit) {
+        playlistViewModel.refreshWatchAvailability()
+    }
+
     var showAddSongsSheet by remember { mutableStateOf(false) }
 
     var isReorderModeEnabled by remember { mutableStateOf(false) }
@@ -200,6 +215,7 @@ fun PlaylistDetailScreen(
     var showPlaylistOptionsSheet by remember { mutableStateOf(false) }
     var showEditPlaylistDialog by remember { mutableStateOf(false) }
     var showDeleteConfirmation by remember { mutableStateOf(false) }
+    var showSendToWatchDialog by remember { mutableStateOf(false) }
 
     val m3uExportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("audio/x-mpegurl")
@@ -213,6 +229,29 @@ fun PlaylistDetailScreen(
 
     val selectedSongForInfo by playerViewModel.selectedSongForInfo.collectAsStateWithLifecycle()
     val favoriteIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle() // Reintroducir favoriteIds aquí
+    val isPixelPlayWatchAvailable by playlistViewModel.isPixelPlayWatchAvailable.collectAsStateWithLifecycle()
+    val isAnyWatchPaired by playlistViewModel.isAnyWatchPaired.collectAsStateWithLifecycle()
+    val watchSongIds by playlistViewModel.watchSongIds.collectAsStateWithLifecycle()
+    val activeBatchTransfer by playlistViewModel.activePlaylistBatchTransfer.collectAsStateWithLifecycle()
+    val activePlaylistTransfer = activeBatchTransfer?.takeIf { it.playlistId == playlistId }
+    // Mutating the playlist while it's mid-transfer to the watch could desync what's actually
+    // being sent from what the user sees on screen — reorder/add/remove are disabled (not
+    // removed, to avoid a layout jump) for the duration.
+    val isTransferActive = activePlaylistTransfer != null
+    // Unlike isTransferActive above (this playlist only), this covers ANY playlist currently
+    // transferring — there's no real transfer queue yet (multiple batches would race over the
+    // watch's single Bluetooth link), so starting a second one is blocked entirely rather than
+    // silently running concurrently.
+    val isAnyBatchTransferActive = activeBatchTransfer != null
+    LaunchedEffect(isTransferActive) {
+        if (isTransferActive) {
+            isReorderModeEnabled = false
+            isRemoveModeEnabled = false
+        }
+    }
+    val isAnySongOnWatch = remember(songsInPlaylist, watchSongIds) {
+        songsInPlaylist.isNotEmpty() && songsInPlaylist.any { it.id in watchSongIds }
+    }
     val stableOnMoreOptionsClick: (Song) -> Unit = remember {
         { song ->
             playerViewModel.selectSongForInfo(song)
@@ -352,14 +391,23 @@ fun PlaylistDetailScreen(
                     .fillMaxSize()
                     .padding(top = innerPadding.calculateTopPadding())
             ) {
+                activePlaylistTransfer?.let { batch ->
+                    WatchTransferProgressBanner(
+                        batch = batch,
+                        onCancelClick = { playlistViewModel.cancelPlaylistTransfer(batch.batchId) },
+                    )
+                }
                 val actionButtonsHeight = 42.dp
-                val playbackControlBottomPadding = if (isFolderPlaylist) 8.dp else 6.dp
+                // Single gap value between every stacked section below (playback row, action
+                // row, search field, song list card) — previously each used its own ad-hoc
+                // value (6dp/8dp/2dp/12dp), which read as visually inconsistent spacing.
+                val sectionSpacing = 12.dp
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(62.dp)
                         .padding(horizontal = 20.dp)
-                        .padding(bottom = playbackControlBottomPadding),
+                        .padding(bottom = sectionSpacing),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Button(
@@ -450,7 +498,8 @@ fun PlaylistDetailScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(start = 20.dp, end = 20.dp, bottom = 8.dp, top = 2.dp),
+                            .padding(horizontal = 20.dp)
+                            .padding(bottom = sectionSpacing),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -482,6 +531,7 @@ fun PlaylistDetailScreen(
 
                         Button(
                             onClick = { showAddSongsSheet = true },
+                            enabled = !isTransferActive,
                             shape = CircleShape,
                             contentPadding = PaddingValues(horizontal = 12.dp),
                             colors = ButtonDefaults.buttonColors(
@@ -547,6 +597,7 @@ fun PlaylistDetailScreen(
                                 content = {
                                     Button(
                                         onClick = { isRemoveModeEnabled = !isRemoveModeEnabled },
+                                        enabled = !isTransferActive,
                                         shape = RoundedCornerShape(removeCornerRadius),
                                         contentPadding = PaddingValues(horizontal = 8.dp),
                                         colors = ButtonDefaults.buttonColors(
@@ -577,6 +628,7 @@ fun PlaylistDetailScreen(
 
                                     Button(
                                         onClick = { isReorderModeEnabled = !isReorderModeEnabled },
+                                        enabled = !isTransferActive,
                                         shape = RoundedCornerShape(reorderCornerRadius),
                                         contentPadding = PaddingValues(horizontal = 8.dp),
                                         colors = ButtonDefaults.buttonColors(
@@ -860,6 +912,18 @@ fun PlaylistDetailScreen(
                         showEditPlaylistDialog = true
                     }
                 )
+                if (isAnyWatchPaired) {
+                    PlaylistActionItem(
+                        icon = painterResource(R.drawable.rounded_watch_arrow_down_24),
+                        label = if (isAnySongOnWatch) updateOnWatchLabel else sendToWatchLabel,
+                        enabled = !isAnyBatchTransferActive,
+                        onClick = {
+                            showPlaylistOptionsSheet = false
+                            playlistViewModel.refreshWatchAvailability()
+                            showSendToWatchDialog = true
+                        }
+                    )
+                }
                 PlaylistActionItem(
                     icon = painterResource(R.drawable.rounded_delete_24),
                     label = deletePlaylistLabel,
@@ -949,6 +1013,90 @@ fun PlaylistDetailScreen(
             dismissButton = {
                 TextButton(onClick = { showDeleteConfirmation = false }) {
                     Text(stringResource(R.string.common_cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+            }
+        )
+    }
+
+    if (showSendToWatchDialog && currentPlaylist != null) {
+        val playlistName = currentPlaylist.name
+        val estimate = remember(songsInPlaylist, watchSongIds) {
+            playlistViewModel.estimateWatchTransfer(songsInPlaylist)
+        }
+        val estimatedSizeText = android.text.format.Formatter.formatShortFileSize(context, estimate.estimatedBytes)
+        val estimatedTimeText = formatListeningDurationCompact(estimate.estimatedTransferSeconds * 1000L)
+        val canSend = isPixelPlayWatchAvailable && estimate.pendingSongCount > 0 && !isAnyBatchTransferActive
+
+        AlertDialog(
+            onDismissRequest = { showSendToWatchDialog = false },
+            title = {
+                Text(
+                    if (isAnySongOnWatch) {
+                        stringResource(R.string.playlist_send_to_watch_dialog_update_title, playlistName)
+                    } else {
+                        stringResource(R.string.playlist_send_to_watch_dialog_title, playlistName)
+                    }
+                )
+            },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    when {
+                        !isPixelPlayWatchAvailable -> Text(stringResource(R.string.playlist_send_to_watch_dialog_watch_unavailable))
+                        estimate.pendingSongCount == 0 -> Text(
+                            stringResource(R.string.playlist_send_to_watch_dialog_all_songs, estimate.totalSongCount)
+                        )
+                        else -> {
+                            Text(
+                                if (estimate.pendingSongCount == estimate.totalSongCount) {
+                                    stringResource(R.string.playlist_send_to_watch_dialog_all_songs, estimate.totalSongCount)
+                                } else {
+                                    stringResource(
+                                        R.string.playlist_send_to_watch_dialog_pending_songs,
+                                        estimate.pendingSongCount,
+                                        estimate.totalSongCount,
+                                    )
+                                }
+                            )
+                            Text(
+                                text = stringResource(
+                                    R.string.playlist_send_to_watch_dialog_estimate,
+                                    estimatedSizeText,
+                                    estimatedTimeText,
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = canSend,
+                    onClick = {
+                        showSendToWatchDialog = false
+                        playlistViewModel.sendPlaylistToWatch(
+                            currentPlaylist.id,
+                            playlistName,
+                            songsInPlaylist.map { it.id },
+                        )
+                        playerViewModel.sendToast(
+                            context.getString(R.string.playlist_watch_transfer_started_toast, playlistName)
+                        )
+                    }
+                ) {
+                    Text(
+                        if (isAnySongOnWatch) {
+                            stringResource(R.string.playlist_send_to_watch_dialog_update_confirm)
+                        } else {
+                            stringResource(R.string.playlist_send_to_watch_dialog_confirm)
+                        }
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSendToWatchDialog = false }) {
+                    Text(stringResource(R.string.common_cancel))
                 }
             }
         )
@@ -1119,15 +1267,17 @@ fun PlaylistDetailScreen(
 private fun PlaylistActionItem(
     icon: Painter,
     label: String,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    enabled: Boolean = true,
 ) {
+    val contentAlpha = if (enabled) 1f else 0.38f
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 6.dp)
             .clip(RoundedCornerShape(18.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            .clickable(onClick = onClick)
+            .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -1141,14 +1291,112 @@ private fun PlaylistActionItem(
             Icon(
                 painter = icon,
                 contentDescription = label,
-                tint = MaterialTheme.colorScheme.primary
+                tint = MaterialTheme.colorScheme.primary.copy(alpha = contentAlpha)
             )
         }
         Spacer(modifier = Modifier.width(14.dp))
         Text(
             text = label,
             style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha)
         )
     }
 }
+
+/**
+ * Non-blocking playlist-transfer indicator shown at the top of the songs list — the user can
+ * leave the screen (or the app) while it continues; the foreground notification (see
+ * `WatchTransferForegroundService`) is what tracks completion once they do.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun WatchTransferProgressBanner(
+    batch: PhoneWatchBatchTransferState,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val overallProgress by remember(batch.processedSongCount, batch.currentSongProgress, batch.totalSongCount) {
+        derivedStateOf {
+            if (batch.totalSongCount > 0) {
+                ((batch.processedSongCount + batch.currentSongProgress) / batch.totalSongCount.toFloat())
+                    .coerceIn(0f, 1f)
+            } else {
+                0f
+            }
+        }
+    }
+    val animatedProgress by animateFloatAsState(
+        targetValue = overallProgress,
+        animationSpec = tween(durationMillis = 300),
+        label = "WatchTransferProgressBanner",
+    )
+
+    // Same icon-badge + row treatment as PlaylistActionItem right below it (40dp circular badge
+    // on surfaceContainerHighest, 16dp horizontal padding, 18dp corner radius) — this banner is
+    // conceptually one more row in that same list, not a separate, unrelated status card.
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.rounded_watch_arrow_down_24),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(
+                    R.string.watch_transfer_batch_progress,
+                    batch.processedSongCount,
+                    batch.totalSongCount,
+                ),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (batch.currentSongTitle.isNotBlank()) {
+                Text(
+                    text = batch.currentSongTitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+            LinearWavyProgressIndicator(
+                progress = { animatedProgress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(50)),
+                color = MaterialTheme.colorScheme.primary,
+                trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            )
+        }
+        Spacer(modifier = Modifier.width(4.dp))
+        IconButton(onClick = onCancelClick) {
+            Icon(
+                imageVector = Icons.Rounded.Close,
+                contentDescription = stringResource(R.string.watch_transfer_action_cancel),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -232,6 +232,7 @@ fun PlaylistDetailScreen(
     val isPixelPlayWatchAvailable by playlistViewModel.isPixelPlayWatchAvailable.collectAsStateWithLifecycle()
     val isAnyWatchPaired by playlistViewModel.isAnyWatchPaired.collectAsStateWithLifecycle()
     val watchSongIds by playlistViewModel.watchSongIds.collectAsStateWithLifecycle()
+    val watchPlaylistIds by playlistViewModel.watchPlaylistIds.collectAsStateWithLifecycle()
     val activeBatchTransfer by playlistViewModel.activePlaylistBatchTransfer.collectAsStateWithLifecycle()
     val activePlaylistTransfer = activeBatchTransfer?.takeIf { it.playlistId == playlistId }
     // Mutating the playlist while it's mid-transfer to the watch could desync what's actually
@@ -249,8 +250,12 @@ fun PlaylistDetailScreen(
             isRemoveModeEnabled = false
         }
     }
-    val isAnySongOnWatch = remember(songsInPlaylist, watchSongIds) {
-        songsInPlaylist.isNotEmpty() && songsInPlaylist.any { it.id in watchSongIds }
+    // "Update" vs "send" is about this playlist having been synced to the watch before, which is
+    // not the same as some of its songs happening to be there: two playlists sharing one song
+    // would otherwise both claim to be already on the watch, and a watch whose app was
+    // reinstalled (library wiped) would still offer "update" for a playlist it no longer has.
+    val isPlaylistOnWatch = remember(playlistId, watchPlaylistIds) {
+        playlistId in watchPlaylistIds
     }
     val stableOnMoreOptionsClick: (Song) -> Unit = remember {
         { song ->
@@ -915,7 +920,7 @@ fun PlaylistDetailScreen(
                 if (isAnyWatchPaired) {
                     PlaylistActionItem(
                         icon = painterResource(R.drawable.rounded_watch_arrow_down_24),
-                        label = if (isAnySongOnWatch) updateOnWatchLabel else sendToWatchLabel,
+                        label = if (isPlaylistOnWatch) updateOnWatchLabel else sendToWatchLabel,
                         enabled = !isAnyBatchTransferActive,
                         onClick = {
                             showPlaylistOptionsSheet = false
@@ -1031,7 +1036,7 @@ fun PlaylistDetailScreen(
             onDismissRequest = { showSendToWatchDialog = false },
             title = {
                 Text(
-                    if (isAnySongOnWatch) {
+                    if (isPlaylistOnWatch) {
                         stringResource(R.string.playlist_send_to_watch_dialog_update_title, playlistName)
                     } else {
                         stringResource(R.string.playlist_send_to_watch_dialog_title, playlistName)
@@ -1086,7 +1091,7 @@ fun PlaylistDetailScreen(
                     }
                 ) {
                     Text(
-                        if (isAnySongOnWatch) {
+                        if (isPlaylistOnWatch) {
                             stringResource(R.string.playlist_send_to_watch_dialog_update_confirm)
                         } else {
                             stringResource(R.string.playlist_send_to_watch_dialog_confirm)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
@@ -74,12 +74,15 @@ import androidx.compose.material.icons.outlined.PlayCircle
 import androidx.compose.material.icons.outlined.Style
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Animation
 import androidx.compose.material.icons.rounded.BlurOff
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.ColorLens
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material.icons.rounded.Image
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Restore
 import androidx.compose.material.icons.rounded.Science
@@ -912,6 +915,44 @@ fun SettingsCategoryScreen(
                                     checked = uiState.hapticsEnabled,
                                     onCheckedChange = { settingsViewModel.setHapticsEnabled(it) },
                                     leadingIcon = { Icon(painterResource(R.drawable.rounded_touch_app_24), null, tint = MaterialTheme.colorScheme.secondary) }
+                                )
+                            }
+                        }
+                        SettingsCategory.WEAR_OS -> {
+                            // Re-announce the current values on entry — covers a freshly paired
+                            // or reinstalled watch that's never received a DataItem sync yet.
+                            LaunchedEffect(Unit) {
+                                settingsViewModel.publishWearPerformanceSettings()
+                            }
+                            SettingsSubsection(
+                                title = stringResource(R.string.settings_wear_performance_section)
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.settings_wear_performance_scope_note),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+                                )
+                                SwitchSettingItem(
+                                    title = stringResource(R.string.settings_wear_show_album_art_title),
+                                    subtitle = stringResource(R.string.settings_wear_show_album_art_subtitle),
+                                    checked = uiState.wearShowAlbumArt,
+                                    onCheckedChange = { settingsViewModel.setWearShowAlbumArt(it) },
+                                    leadingIcon = { Icon(Icons.Rounded.Image, null, tint = MaterialTheme.colorScheme.secondary) }
+                                )
+                                SwitchSettingItem(
+                                    title = stringResource(R.string.settings_wear_dynamic_color_title),
+                                    subtitle = stringResource(R.string.settings_wear_dynamic_color_subtitle),
+                                    checked = uiState.wearDynamicColorTheming,
+                                    onCheckedChange = { settingsViewModel.setWearDynamicColorTheming(it) },
+                                    leadingIcon = { Icon(Icons.Rounded.ColorLens, null, tint = MaterialTheme.colorScheme.secondary) }
+                                )
+                                SwitchSettingItem(
+                                    title = stringResource(R.string.settings_wear_play_button_animation_title),
+                                    subtitle = stringResource(R.string.settings_wear_play_button_animation_subtitle),
+                                    checked = uiState.wearPlayButtonAnimation,
+                                    onCheckedChange = { settingsViewModel.setWearPlayButtonAnimation(it) },
+                                    leadingIcon = { Icon(Icons.Rounded.Animation, null, tint = MaterialTheme.colorScheme.secondary) }
                                 )
                             }
                         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
@@ -131,6 +131,8 @@ fun SettingsScreen(
     val uiState by settingsViewModel.uiState.collectAsStateWithLifecycle()
     val launchTab = uiState.launchTab
     val useSmoothCorners by settingsViewModel.useSmoothCorners.collectAsStateWithLifecycle()
+    val isAnyWatchPaired by settingsViewModel.isAnyWatchPaired.collectAsStateWithLifecycle()
+    LaunchedEffect(Unit) { settingsViewModel.refreshWatchPairingState() }
 
     var showCornerRadiusOverlay by remember { mutableStateOf(false) }
 
@@ -214,8 +216,9 @@ fun SettingsScreen(
                 val isDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
                 ExpressiveSettingsGroup {
                     val mainCategories = SettingsCategory.entries.filter {
-                        it != SettingsCategory.ABOUT && 
-                        it != SettingsCategory.DEVICE_CAPABILITIES
+                        it != SettingsCategory.ABOUT &&
+                        it != SettingsCategory.DEVICE_CAPABILITIES &&
+                        (it != SettingsCategory.WEAR_OS || isAnyWatchPaired)
                     }
 
                     val totalItems = mainCategories.size + 3 // Device + Accounts + About
@@ -487,7 +490,8 @@ private fun getCategoryColors(category: SettingsCategory, isDark: Boolean): Pair
             SettingsCategory.DEVELOPER -> Color(0xFF324F34) to Color(0xFFCBEFD0) 
             SettingsCategory.EQUALIZER -> Color(0xFF6E4E13) to Color(0xFFFFDEAC) 
             SettingsCategory.DEVICE_CAPABILITIES -> Color(0xFF004D61) to Color(0xFFACEFEE) // Custom teal/cyan mix
-            SettingsCategory.ABOUT -> Color(0xFF3F474D) to Color(0xFFDEE3EB) 
+            SettingsCategory.WEAR_OS -> Color(0xFF3B4869) to Color(0xFFD9E2FF) // Same family as BACKUP_RESTORE
+            SettingsCategory.ABOUT -> Color(0xFF3F474D) to Color(0xFFDEE3EB)
         }
     } else {
         when (category) {
@@ -500,6 +504,7 @@ private fun getCategoryColors(category: SettingsCategory, isDark: Boolean): Pair
             SettingsCategory.DEVELOPER -> Color(0xFFCBEFD0) to Color(0xFF042106)
             SettingsCategory.EQUALIZER -> Color(0xFFFFDEAC) to Color(0xFF281900)
             SettingsCategory.DEVICE_CAPABILITIES -> Color(0xFFACEFEE) to Color(0xFF002022)
+            SettingsCategory.WEAR_OS -> Color(0xFFD9E2FF) to Color(0xFF27304E)
             SettingsCategory.ABOUT -> Color(0xFFEFF1F7) to Color(0xFF44474F)
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -107,6 +107,9 @@ class PlaylistViewModel @Inject constructor(
     private val _isRefreshingWatchAvailability = MutableStateFlow(false)
     val watchSongIds: StateFlow<Set<String>> = watchTransferStateStore.watchSongIds
 
+    /** Playlists the watch itself reports having, which is what "send" vs "update" hinges on. */
+    val watchPlaylistIds: StateFlow<Set<String>> = watchTransferStateStore.watchPlaylistIds
+
     /** Whether any watch has ever been paired with PixelPlay installed — as opposed to
      *  [isPixelPlayWatchAvailable], which is "reachable right now". Gates whether watch-related
      *  actions show at all, vs. showing disabled for a paired-but-out-of-range watch. */

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -14,6 +14,14 @@ import com.theveloper.pixelplay.data.model.SortOption
 import com.theveloper.pixelplay.data.playlist.M3uManager
 import com.theveloper.pixelplay.data.preferences.PlaylistPreferencesRepository
 import com.theveloper.pixelplay.data.repository.MusicRepository
+import com.theveloper.pixelplay.data.service.wear.PhoneWatchBatchTransferState
+import com.theveloper.pixelplay.data.service.wear.PhoneWatchTransferStateStore
+import com.theveloper.pixelplay.data.service.wear.PlaylistWatchTransferCoordinator
+import com.theveloper.pixelplay.data.service.wear.WatchAudioTranscoder
+import com.theveloper.pixelplay.data.service.wear.WatchPlaylistTransferEstimate
+import com.theveloper.pixelplay.data.service.wear.WatchPlaylistTransferEstimator
+import com.theveloper.pixelplay.data.service.wear.WearPhoneTransferSender
+import com.theveloper.pixelplay.shared.WearTransferProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +30,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -75,6 +86,10 @@ class PlaylistViewModel @Inject constructor(
     private val dailyMixManager: DailyMixManager,
     private val aiPlaylistGenerator: AiPlaylistGenerator,
     private val m3uManager: M3uManager,
+    private val playlistWatchTransferCoordinator: PlaylistWatchTransferCoordinator,
+    private val watchTransferStateStore: PhoneWatchTransferStateStore,
+    private val wearPhoneTransferSender: WearPhoneTransferSender,
+    private val watchAudioTranscoder: WatchAudioTranscoder,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -87,10 +102,39 @@ class PlaylistViewModel @Inject constructor(
     )
     val playlistCreationEvent: SharedFlow<Boolean> = _playlistCreationEvent.asSharedFlow()
 
+    private val _isPixelPlayWatchAvailable = MutableStateFlow(false)
+    val isPixelPlayWatchAvailable: StateFlow<Boolean> = _isPixelPlayWatchAvailable.asStateFlow()
+    private val _isRefreshingWatchAvailability = MutableStateFlow(false)
+    val watchSongIds: StateFlow<Set<String>> = watchTransferStateStore.watchSongIds
+
+    /** Whether any watch has ever been paired with PixelPlay installed — as opposed to
+     *  [isPixelPlayWatchAvailable], which is "reachable right now". Gates whether watch-related
+     *  actions show at all, vs. showing disabled for a paired-but-out-of-range watch. */
+    val isAnyWatchPaired: StateFlow<Boolean> = watchTransferStateStore.isAnyWatchPaired
+
+    /**
+     * Whichever playlist batch transfer is currently active, regardless of which screen/ViewModel
+     * instance started it — queried off the shared [PhoneWatchTransferStateStore] instead of
+     * remembering "the last batchId this instance kicked off", so re-entering the detail screen
+     * for the same playlist still sees a batch already in flight.
+     */
+    val activePlaylistBatchTransfer: StateFlow<PhoneWatchBatchTransferState?> = watchTransferStateStore.batchTransfers
+        .map { batches -> batches.values.firstOrNull { it.status !in TERMINAL_BATCH_STATUSES } }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = null,
+        )
+
     companion object {
         const val FOLDER_PLAYLIST_PREFIX = "folder_playlist:"
         private const val MANUAL_ORDER_MODE = "manual"
         private const val SMART_PLAYLIST_MAX_ITEMS = 100
+        private val TERMINAL_BATCH_STATUSES = setOf(
+            WearTransferProgress.STATUS_COMPLETED,
+            WearTransferProgress.STATUS_FAILED,
+            WearTransferProgress.STATUS_CANCELLED,
+        )
 
         fun sanitizeFileName(name: String): String {
             val sanitized = name.replace(Regex("[\\\\/:*?\"<>|\\s]+"), "_").trim('_')
@@ -1223,5 +1267,47 @@ class PlaylistViewModel @Inject constructor(
                 Toast.makeText(context, context.getString(R.string.playlist_view_model_export_failed, e.message ?: ""), Toast.LENGTH_SHORT).show()
             }
         }
+    }
+
+    // --- Watch transfer ---
+
+    /**
+     * Refreshes reachable-watch capability + free storage. Call before showing the send-to-watch
+     * confirmation sheet so its estimate and availability state are current.
+     */
+    fun refreshWatchAvailability() {
+        if (_isRefreshingWatchAvailability.value) return
+
+        viewModelScope.launch {
+            _isRefreshingWatchAvailability.value = true
+            val available = wearPhoneTransferSender.isPixelPlayWatchAvailable()
+            _isPixelPlayWatchAvailable.value = available
+            _isRefreshingWatchAvailability.value = false
+            if (available) {
+                wearPhoneTransferSender.refreshWatchLibraryState()
+            }
+        }
+        viewModelScope.launch {
+            wearPhoneTransferSender.refreshWatchPairingState()
+        }
+    }
+
+    fun isPlaylistFullyOnWatch(songIds: List<String>): Boolean {
+        return songIds.isNotEmpty() && songIds.all { watchTransferStateStore.isSongSavedOnAllReachableWatches(it) }
+    }
+
+    /** Size/time estimate over only the songs from [songs] that aren't already on every reachable watch. */
+    fun estimateWatchTransfer(songs: List<Song>): WatchPlaylistTransferEstimate {
+        val pendingSongs = songs.filterNot { watchTransferStateStore.isSongSavedOnAllReachableWatches(it.id) }
+        return WatchPlaylistTransferEstimator.estimate(songs, pendingSongs, watchAudioTranscoder)
+    }
+
+    /** Returns the generated batchId immediately; the transfer itself runs asynchronously. */
+    fun sendPlaylistToWatch(playlistId: String, playlistName: String, songIds: List<String>): String {
+        return playlistWatchTransferCoordinator.requestPlaylistTransfer(playlistId, playlistName, songIds)
+    }
+
+    fun cancelPlaylistTransfer(batchId: String) {
+        playlistWatchTransferCoordinator.cancelPlaylistTransfer(batchId)
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
@@ -111,7 +111,11 @@ data class SettingsUiState(
     val replayGainEnabled: Boolean = false,
     val replayGainUseAlbumGain: Boolean = false,
     val isSafeTokenLimitEnabled: Boolean = true,
-    val showScrollbar: Boolean = true
+    val showScrollbar: Boolean = true,
+    // Wear OS performance toggles — only apply during standalone local playback on the watch.
+    val wearShowAlbumArt: Boolean = true,
+    val wearDynamicColorTheming: Boolean = true,
+    val wearPlayButtonAnimation: Boolean = true,
 )
 
 data class FailedSongInfo(
@@ -190,11 +194,27 @@ class SettingsViewModel @Inject constructor(
     private val lyricsRepository: LyricsRepository,
     private val musicRepository: MusicRepository,
     private val backupManager: BackupManager,
+    private val wearPerformanceSettingsPublisher: com.theveloper.pixelplay.data.service.wear.WearPerformanceSettingsPublisher,
+    private val wearPhoneTransferSender: com.theveloper.pixelplay.data.service.wear.WearPhoneTransferSender,
+    private val watchTransferStateStore: com.theveloper.pixelplay.data.service.wear.PhoneWatchTransferStateStore,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    /** Whether any watch has ever been paired with PixelPlay installed — gates whether the
+     *  "Watch" category even shows in the Settings hub. See PlaylistViewModel's identical field
+     *  for the full explanation of why this differs from "reachable right now". */
+    val isAnyWatchPaired: StateFlow<Boolean> = watchTransferStateStore.isAnyWatchPaired
+
+    /** Re-checks watch pairing state — call once when the Settings hub (or "Watch" category)
+     *  opens, on top of the app-startup check, in case a watch was paired mid-session. */
+    fun refreshWatchPairingState() {
+        viewModelScope.launch {
+            wearPhoneTransferSender.refreshWatchPairingState()
+        }
+    }
 
     // AI Provider State
     val aiProvider: StateFlow<String> = aiPreferencesRepository.aiProvider
@@ -764,6 +784,24 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             userPreferencesRepository.tapBackgroundClosesPlayerFlow.collect { enabled ->
                 _uiState.update { it.copy(tapBackgroundClosesPlayer = enabled) }
+            }
+        }
+
+        viewModelScope.launch {
+            userPreferencesRepository.wearShowAlbumArtFlow.collect { enabled ->
+                _uiState.update { it.copy(wearShowAlbumArt = enabled) }
+            }
+        }
+
+        viewModelScope.launch {
+            userPreferencesRepository.wearDynamicColorThemingFlow.collect { enabled ->
+                _uiState.update { it.copy(wearDynamicColorTheming = enabled) }
+            }
+        }
+
+        viewModelScope.launch {
+            userPreferencesRepository.wearPlayButtonAnimationFlow.collect { enabled ->
+                _uiState.update { it.copy(wearPlayButtonAnimation = enabled) }
             }
         }
 
@@ -1368,6 +1406,65 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             userPreferencesRepository.setHapticsEnabled(enabled)
         }
+    }
+
+    fun setWearShowAlbumArt(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setWearShowAlbumArt(enabled)
+            publishWearPerformanceSettings(showAlbumArtOverride = enabled)
+        }
+    }
+
+    fun setWearDynamicColorTheming(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setWearDynamicColorTheming(enabled)
+            publishWearPerformanceSettings(dynamicColorThemingOverride = enabled)
+        }
+    }
+
+    fun setWearPlayButtonAnimation(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setWearPlayButtonAnimation(enabled)
+            publishWearPerformanceSettings(playButtonAnimationOverride = enabled)
+        }
+    }
+
+    /**
+     * Publishes the current watch performance settings to the watch. Called once when the
+     * "Watch" settings screen opens (no overrides — just re-announces whatever's persisted, so a
+     * freshly paired or reinstalled watch gets them without the user touching a toggle first,
+     * since DataItem sync only reaches a node once something's actually been `putDataItem`'d at
+     * least once), and after each individual setter above with that field's fresh value passed as
+     * an override.
+     *
+     * Deliberately reads the other (non-overridden) fields straight from
+     * [UserPreferencesRepository]'s flows via `.first()`, not from `uiState.value`: `uiState` is
+     * updated by a separate reactive collector that isn't guaranteed to have caught up to a write
+     * that just happened a moment ago on a *different* setter call — flipping two switches in
+     * quick succession could publish a stale value for whichever one's collector hadn't run yet,
+     * silently reverting it on the watch. Reading the repository directly has no such race: by
+     * the time this runs, every `set...()` call that's already returned has durably completed its
+     * `DataStore.edit`, so a fresh `.first()` always reflects it.
+     */
+    private fun publishWearPerformanceSettings(
+        showAlbumArtOverride: Boolean? = null,
+        dynamicColorThemingOverride: Boolean? = null,
+        playButtonAnimationOverride: Boolean? = null,
+    ) {
+        viewModelScope.launch {
+            wearPerformanceSettingsPublisher.publish(
+                showAlbumArt = showAlbumArtOverride
+                    ?: userPreferencesRepository.wearShowAlbumArtFlow.first(),
+                dynamicColorTheming = dynamicColorThemingOverride
+                    ?: userPreferencesRepository.wearDynamicColorThemingFlow.first(),
+                playButtonAnimation = playButtonAnimationOverride
+                    ?: userPreferencesRepository.wearPlayButtonAnimationFlow.first(),
+            )
+        }
+    }
+
+    fun publishWearPerformanceSettings() {
+        publishWearPerformanceSettings(null, null, null)
     }
 
     fun setBackupInfoDismissed(dismissed: Boolean) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
@@ -77,6 +77,10 @@ class SongInfoBottomSheetViewModel @Inject constructor(
     val isWatchAvailabilityResolved: StateFlow<Boolean> = _isWatchAvailabilityResolved.asStateFlow()
     private val _isRefreshingWatchAvailability = MutableStateFlow(false)
 
+    /** Whether any watch has ever been paired with PixelPlay installed — see PlaylistViewModel's
+     *  identical field for the full explanation. */
+    val isAnyWatchPaired: StateFlow<Boolean> = transferStateStore.isAnyWatchPaired
+
     private val _isRequestingToWatch = MutableStateFlow(false)
     val watchTransfers: StateFlow<Map<String, PhoneWatchTransferState>> = transferStateStore.transfers
     val watchSongIds: StateFlow<Set<String>> = transferStateStore.watchSongIds
@@ -172,6 +176,9 @@ class SongInfoBottomSheetViewModel @Inject constructor(
                     wearPhoneTransferSender.refreshWatchLibraryState()
                 }
             }
+        }
+        viewModelScope.launch {
+            wearPhoneTransferSender.refreshWatchPairingState()
         }
     }
 

--- a/app/src/main/res/values-ar/strings_settings.xml
+++ b/app/src/main/res/values-ar/strings_settings.xml
@@ -306,4 +306,16 @@
     <string name="settings_volume_section">مستوى الصوت</string>
     <string name="settings_pause_on_volume_zero">إيقاف مؤقت عند وصول مستوى الصوت إلى الصفر</string>
     <string name="settings_pause_on_volume_zero_desc">إيقاف التشغيل تلقائيًا مؤقتًا عندما يكون مستوى الصوت 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">الساعة</string>
+    <string name="settings_category_wear_subtitle">خيارات الأداء للتشغيل دون اتصال على ساعتك</string>
+    <string name="settings_wear_performance_section">الأداء</string>
+    <string name="settings_wear_performance_scope_note">تنطبق هذه الخيارات فقط عندما تشغّل ساعتك الموسيقى بمفردها، دون اتصال بالهاتف. يعرض التحكم في تشغيل الهاتف من الساعة التجربة الكاملة دائمًا.</string>
+    <string name="settings_wear_show_album_art_title">إظهار غلاف الألبوم</string>
+    <string name="settings_wear_show_album_art_subtitle">أوقف التشغيل لتوفير الذاكرة على الساعة — الأكبر تأثيرًا من بين الثلاثة</string>
+    <string name="settings_wear_dynamic_color_title">اللون الديناميكي</string>
+    <string name="settings_wear_dynamic_color_subtitle">يلوّن واجهة الساعة وفقًا لغلاف كل أغنية</string>
+    <string name="settings_wear_play_button_animation_title">رسوم زر التشغيل المتحركة</string>
+    <string name="settings_wear_play_button_animation_subtitle">حلقة تدور باستمرار حول زر التشغيل أثناء تشغيل الموسيقى</string>
 </resources>

--- a/app/src/main/res/values-de/strings_settings.xml
+++ b/app/src/main/res/values-de/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">Lautstärke</string>
     <string name="settings_pause_on_volume_zero">Pausieren, wenn Lautstärke null erreicht</string>
     <string name="settings_pause_on_volume_zero_desc">Wiedergabe automatisch pausieren, wenn die Lautstärke auf 0 gesetzt wird</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Uhr</string>
+    <string name="settings_category_wear_subtitle">Leistungsoptionen für die Offline-Wiedergabe auf deiner Uhr</string>
+    <string name="settings_wear_performance_section">Leistung</string>
+    <string name="settings_wear_performance_scope_note">Diese Optionen gelten nur, wenn deine Uhr Musik eigenständig abspielt, ohne verbundenes Smartphone. Wenn du die Wiedergabe auf dem Smartphone von der Uhr aus steuerst, wird immer die vollständige Ansicht angezeigt.</string>
+    <string name="settings_wear_show_album_art_title">Albumcover anzeigen</string>
+    <string name="settings_wear_show_album_art_subtitle">Deaktivieren, um Speicher auf der Uhr zu sparen — hat von den dreien die größte Wirkung</string>
+    <string name="settings_wear_dynamic_color_title">Dynamische Farbe</string>
+    <string name="settings_wear_dynamic_color_subtitle">Färbt die Oberfläche der Uhr passend zum Cover des jeweiligen Songs</string>
+    <string name="settings_wear_play_button_animation_title">Animation der Wiedergabetaste</string>
+    <string name="settings_wear_play_button_animation_subtitle">Durchgehend rotierender Ring um die Wiedergabetaste, während Musik läuft</string>
 </resources>

--- a/app/src/main/res/values-es/strings_library.xml
+++ b/app/src/main/res/values-es/strings_library.xml
@@ -265,9 +265,12 @@
 
     <!-- Watch Transfer Dialog + Foreground Service -->
     <string name="watch_transfer_action_cancel">Cancelar transferencia</string>
+    <string name="watch_transfer_batch_failed_count">%1$d canciones fallidas</string>
+    <string name="watch_transfer_batch_progress">%1$d de %2$d canciones</string>
     <string name="watch_transfer_bytes_progress">%1$s / %2$s</string>
     <string name="watch_transfer_channel_description">Muestra el progreso en tiempo real de las transferencias de música del teléfono al reloj</string>
     <string name="watch_transfer_channel_name">Transferencias al reloj</string>
+    <string name="watch_transfer_current_song">Enviando: %1$s</string>
     <string name="watch_transfer_dialog_title">Enviando al reloj</string>
     <string name="watch_transfer_status_cancelled">Cancelado</string>
     <string name="watch_transfer_status_cancelled_service">Transferencia cancelada</string>
@@ -281,6 +284,7 @@
     <string name="watch_transfer_status_preparing_service">Preparando transferencia al reloj</string>
     <string name="watch_transfer_status_preparing_transfer">Preparando transferencia…</string>
     <string name="watch_transfer_status_sending_n_to_watch">Enviando %1$d canciones al reloj</string>
+    <string name="watch_transfer_status_sending_playlist_to_watch">Enviando \"%1$s\" al reloj</string>
     <string name="watch_transfer_status_sending_to_watch">Enviando al reloj</string>
     <string name="watch_transfer_status_starting">Iniciando transferencia…</string>
     <string name="watch_transfer_status_starting_short">Iniciando</string>

--- a/app/src/main/res/values-es/strings_screens.xml
+++ b/app/src/main/res/values-es/strings_screens.xml
@@ -126,6 +126,19 @@
     <string name="playlist_cd_remove_songs">Quitar canciones</string>
     <string name="playlist_action_reorder_songs">Reordenar</string>
     <string name="playlist_cd_reorder_songs">Reordenar canciones</string>
+    <string name="playlist_action_send_to_watch">Enviar al reloj</string>
+    <string name="playlist_action_update_on_watch">Actualizar en el reloj</string>
+    <string name="playlist_cd_send_to_watch">Enviar lista al reloj</string>
+    <string name="playlist_send_to_watch_dialog_title">¿Enviar \"%1$s\" a tu reloj?</string>
+    <string name="playlist_send_to_watch_dialog_update_title">¿Actualizar \"%1$s\" en tu reloj?</string>
+    <string name="playlist_send_to_watch_dialog_pending_songs">%1$d de %2$d canciones por enviar</string>
+    <string name="playlist_send_to_watch_dialog_all_songs">%1$d canciones</string>
+    <string name="playlist_send_to_watch_dialog_estimate">%1$s · unos %2$s</string>
+    <string name="playlist_send_to_watch_dialog_confirm">Enviar</string>
+    <string name="playlist_send_to_watch_dialog_update_confirm">Actualizar</string>
+    <string name="playlist_send_to_watch_dialog_watch_unavailable">Ningún reloj conectado</string>
+    <string name="playlist_watch_transfer_started_toast">Enviando \"%1$s\" a tu reloj</string>
+    <string name="playlist_watch_transfer_start_failed_toast">No se pudo iniciar la transferencia: %1$s</string>
 
     <!-- EditTransitionScreen -->
     <string name="transition_title_global">Transiciones globales</string>

--- a/app/src/main/res/values-es/strings_settings.xml
+++ b/app/src/main/res/values-es/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">Volumen</string>
     <string name="settings_pause_on_volume_zero">Pausar cuando el volumen llegue a cero</string>
     <string name="settings_pause_on_volume_zero_desc">Pausar automáticamente la reproducción cuando el volumen sea 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Reloj</string>
+    <string name="settings_category_wear_subtitle">Opciones de rendimiento para la reproducción sin conexión en tu reloj</string>
+    <string name="settings_wear_performance_section">Rendimiento</string>
+    <string name="settings_wear_performance_scope_note">Estas opciones solo aplican cuando tu reloj reproduce música por su cuenta, sin el teléfono conectado. Controlar la reproducción del teléfono desde el reloj siempre muestra la experiencia completa.</string>
+    <string name="settings_wear_show_album_art_title">Mostrar carátula del álbum</string>
+    <string name="settings_wear_show_album_art_subtitle">Desactívalo para ahorrar memoria en el reloj — el de mayor impacto de los tres</string>
+    <string name="settings_wear_dynamic_color_title">Color dinámico</string>
+    <string name="settings_wear_dynamic_color_subtitle">Tiñe la interfaz del reloj según la carátula de cada canción</string>
+    <string name="settings_wear_play_button_animation_title">Animación del botón de reproducción</string>
+    <string name="settings_wear_play_button_animation_subtitle">Anillo giratorio continuo alrededor del botón de reproducción mientras suena la música</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_settings.xml
+++ b/app/src/main/res/values-fr/strings_settings.xml
@@ -642,4 +642,16 @@
     <string name="settings_volume_section">Volume</string>
     <string name="settings_pause_on_volume_zero">Mettre en pause quand le volume atteint zéro</string>
     <string name="settings_pause_on_volume_zero_desc">Mettre automatiquement en pause la lecture lorsque le volume est à 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Montre</string>
+    <string name="settings_category_wear_subtitle">Options de performance pour la lecture hors ligne sur votre montre</string>
+    <string name="settings_wear_performance_section">Performance</string>
+    <string name="settings_wear_performance_scope_note">Ces options s\'appliquent uniquement lorsque votre montre lit de la musique de manière autonome, sans connexion au téléphone. Le contrôle de la lecture du téléphone depuis la montre affiche toujours l\'expérience complète.</string>
+    <string name="settings_wear_show_album_art_title">Afficher la pochette de l\'album</string>
+    <string name="settings_wear_show_album_art_subtitle">Désactivez pour économiser la mémoire de la montre — l\'option ayant le plus d\'impact des trois</string>
+    <string name="settings_wear_dynamic_color_title">Couleur dynamique</string>
+    <string name="settings_wear_dynamic_color_subtitle">Teinte l\'interface de la montre selon la pochette de chaque morceau</string>
+    <string name="settings_wear_play_button_animation_title">Animation du bouton de lecture</string>
+    <string name="settings_wear_play_button_animation_subtitle">Anneau tournant en continu autour du bouton de lecture pendant la musique</string>
 </resources>

--- a/app/src/main/res/values-in/strings_settings.xml
+++ b/app/src/main/res/values-in/strings_settings.xml
@@ -642,4 +642,16 @@
     <string name="settings_volume_section">Volume</string>
     <string name="settings_pause_on_volume_zero">Jeda saat volume mencapai nol</string>
     <string name="settings_pause_on_volume_zero_desc">Otomatis menjeda pemutaran saat volume diatur ke 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Jam Tangan</string>
+    <string name="settings_category_wear_subtitle">Opsi performa untuk pemutaran offline di jam tangan Anda</string>
+    <string name="settings_wear_performance_section">Performa</string>
+    <string name="settings_wear_performance_scope_note">Opsi ini hanya berlaku saat jam tangan Anda memutar musik secara mandiri, tanpa ponsel terhubung. Mengontrol pemutaran ponsel dari jam tangan selalu menampilkan pengalaman lengkap.</string>
+    <string name="settings_wear_show_album_art_title">Tampilkan sampul album</string>
+    <string name="settings_wear_show_album_art_subtitle">Nonaktifkan untuk menghemat memori di jam tangan — dampak terbesar dari ketiganya</string>
+    <string name="settings_wear_dynamic_color_title">Warna dinamis</string>
+    <string name="settings_wear_dynamic_color_subtitle">Mewarnai antarmuka jam tangan berdasarkan sampul setiap lagu</string>
+    <string name="settings_wear_play_button_animation_title">Animasi tombol putar</string>
+    <string name="settings_wear_play_button_animation_subtitle">Cincin berputar terus-menerus di sekitar tombol putar saat musik diputar</string>
 </resources>

--- a/app/src/main/res/values-it/strings_settings.xml
+++ b/app/src/main/res/values-it/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">Volume</string>
     <string name="settings_pause_on_volume_zero">Metti in pausa quando il volume raggiunge zero</string>
     <string name="settings_pause_on_volume_zero_desc">Metti automaticamente in pausa la riproduzione quando il volume è 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Orologio</string>
+    <string name="settings_category_wear_subtitle">Opzioni di prestazioni per la riproduzione offline sul tuo orologio</string>
+    <string name="settings_wear_performance_section">Prestazioni</string>
+    <string name="settings_wear_performance_scope_note">Queste opzioni si applicano solo quando il tuo orologio riproduce musica in autonomia, senza il telefono connesso. Controllare la riproduzione del telefono dall\'orologio mostra sempre l\'esperienza completa.</string>
+    <string name="settings_wear_show_album_art_title">Mostra copertina dell\'album</string>
+    <string name="settings_wear_show_album_art_subtitle">Disattiva per risparmiare memoria sull\'orologio — quella con il maggiore impatto delle tre</string>
+    <string name="settings_wear_dynamic_color_title">Colore dinamico</string>
+    <string name="settings_wear_dynamic_color_subtitle">Colora l\'interfaccia dell\'orologio in base alla copertina di ogni brano</string>
+    <string name="settings_wear_play_button_animation_title">Animazione del pulsante di riproduzione</string>
+    <string name="settings_wear_play_button_animation_subtitle">Anello che ruota continuamente attorno al pulsante di riproduzione durante la musica</string>
 </resources>

--- a/app/src/main/res/values-ko/strings_settings.xml
+++ b/app/src/main/res/values-ko/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">볼륨</string>
     <string name="settings_pause_on_volume_zero">볼륨이 0이 되면 일시정지</string>
     <string name="settings_pause_on_volume_zero_desc">볼륨이 0으로 설정되면 자동으로 재생을 일시정지합니다</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">워치</string>
+    <string name="settings_category_wear_subtitle">워치에서 오프라인 재생을 위한 성능 옵션</string>
+    <string name="settings_wear_performance_section">성능</string>
+    <string name="settings_wear_performance_scope_note">이 옵션은 워치가 휴대폰 연결 없이 단독으로 음악을 재생할 때만 적용됩니다. 워치에서 휴대폰 재생을 제어할 때는 항상 전체 화면이 표시됩니다.</string>
+    <string name="settings_wear_show_album_art_title">앨범 아트 표시</string>
+    <string name="settings_wear_show_album_art_subtitle">워치의 메모리를 절약하려면 꺼두세요 — 세 가지 중 가장 큰 영향을 미칩니다</string>
+    <string name="settings_wear_dynamic_color_title">다이내믹 컬러</string>
+    <string name="settings_wear_dynamic_color_subtitle">각 곡의 앨범 아트에 따라 워치 UI 색상을 지정합니다</string>
+    <string name="settings_wear_play_button_animation_title">재생 버튼 애니메이션</string>
+    <string name="settings_wear_play_button_animation_subtitle">음악 재생 중 재생 버튼 주위로 계속 회전하는 링</string>
 </resources>

--- a/app/src/main/res/values-nb/strings_settings.xml
+++ b/app/src/main/res/values-nb/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">Volum</string>
     <string name="settings_pause_on_volume_zero">Sett på pause når volumet er null</string>
     <string name="settings_pause_on_volume_zero_desc">Sett automatisk avspillingen på pause når volumet settes til 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Klokke</string>
+    <string name="settings_category_wear_subtitle">Ytelsesalternativer for frakoblet avspilling på klokken din</string>
+    <string name="settings_wear_performance_section">Ytelse</string>
+    <string name="settings_wear_performance_scope_note">Disse alternativene gjelder bare når klokken din spiller musikk på egen hånd, uten tilkoblet telefon. Å styre telefonavspilling fra klokken viser alltid hele opplevelsen.</string>
+    <string name="settings_wear_show_album_art_title">Vis albumcover</string>
+    <string name="settings_wear_show_album_art_subtitle">Slå av for å spare minne på klokken — den med størst innvirkning av de tre</string>
+    <string name="settings_wear_dynamic_color_title">Dynamisk farge</string>
+    <string name="settings_wear_dynamic_color_subtitle">Fargelegger klokkens grensesnitt basert på coveret til hver sang</string>
+    <string name="settings_wear_play_button_animation_title">Animasjon for avspillingsknapp</string>
+    <string name="settings_wear_play_button_animation_subtitle">Kontinuerlig roterende ring rundt avspillingsknappen mens musikken spilles</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_settings.xml
+++ b/app/src/main/res/values-ru/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">Громкость</string>
     <string name="settings_pause_on_volume_zero">Пауза при нулевой громкости</string>
     <string name="settings_pause_on_volume_zero_desc">Автоматически приостанавливать воспроизведение, когда громкость равна 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Часы</string>
+    <string name="settings_category_wear_subtitle">Настройки производительности для автономного воспроизведения на часах</string>
+    <string name="settings_wear_performance_section">Производительность</string>
+    <string name="settings_wear_performance_scope_note">Эти параметры применяются, только когда часы воспроизводят музыку самостоятельно, без подключения к телефону. Управление воспроизведением на телефоне с часов всегда показывает полный интерфейс.</string>
+    <string name="settings_wear_show_album_art_title">Показывать обложку альбома</string>
+    <string name="settings_wear_show_album_art_subtitle">Отключите, чтобы сэкономить память на часах — оказывает наибольшее влияние из трёх</string>
+    <string name="settings_wear_dynamic_color_title">Динамический цвет</string>
+    <string name="settings_wear_dynamic_color_subtitle">Окрашивает интерфейс часов по обложке каждой песни</string>
+    <string name="settings_wear_play_button_animation_title">Анимация кнопки воспроизведения</string>
+    <string name="settings_wear_play_button_animation_subtitle">Непрерывно вращающееся кольцо вокруг кнопки воспроизведения во время игры музыки</string>
 </resources>

--- a/app/src/main/res/values-tr/strings_settings.xml
+++ b/app/src/main/res/values-tr/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">Ses</string>
     <string name="settings_pause_on_volume_zero">Ses sıfıra ulaştığında duraklat</string>
     <string name="settings_pause_on_volume_zero_desc">Ses seviyesi 0\'a ayarlandığında oynatmayı otomatik olarak duraklat</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">Saat</string>
+    <string name="settings_category_wear_subtitle">Saatinizde çevrimdışı oynatma için performans seçenekleri</string>
+    <string name="settings_wear_performance_section">Performans</string>
+    <string name="settings_wear_performance_scope_note">Bu seçenekler yalnızca saatiniz telefon bağlı olmadan kendi başına müzik çaldığında geçerlidir. Telefon oynatımını saatten kontrol etmek her zaman tam deneyimi gösterir.</string>
+    <string name="settings_wear_show_album_art_title">Albüm kapağını göster</string>
+    <string name="settings_wear_show_album_art_subtitle">Saatte bellekten tasarruf etmek için kapatın — üçü arasında en büyük etkiye sahip olan</string>
+    <string name="settings_wear_dynamic_color_title">Dinamik renk</string>
+    <string name="settings_wear_dynamic_color_subtitle">Saat arayüzünü her şarkının kapak resmine göre renklendirir</string>
+    <string name="settings_wear_play_button_animation_title">Oynat düğmesi animasyonu</string>
+    <string name="settings_wear_play_button_animation_subtitle">Müzik çalarken oynat düğmesinin etrafında sürekli dönen halka</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_settings.xml
+++ b/app/src/main/res/values-zh-rCN/strings_settings.xml
@@ -646,4 +646,16 @@
     <string name="settings_volume_section">音量</string>
     <string name="settings_pause_on_volume_zero">音量为零时暂停</string>
     <string name="settings_pause_on_volume_zero_desc">当音量设置为 0 时自动暂停播放</string>
+
+    <!-- Watch category -->
+    <string name="settings_category_wear_title">手表</string>
+    <string name="settings_category_wear_subtitle">手表离线播放的性能选项</string>
+    <string name="settings_wear_performance_section">性能</string>
+    <string name="settings_wear_performance_scope_note">这些选项仅在您的手表脱离手机独立播放音乐时生效。从手表控制手机播放时，始终显示完整体验。</string>
+    <string name="settings_wear_show_album_art_title">显示专辑封面</string>
+    <string name="settings_wear_show_album_art_subtitle">关闭以节省手表内存 — 三项中影响最大的一项</string>
+    <string name="settings_wear_dynamic_color_title">动态颜色</string>
+    <string name="settings_wear_dynamic_color_subtitle">根据每首歌曲的封面为手表界面着色</string>
+    <string name="settings_wear_play_button_animation_title">播放按钮动画</string>
+    <string name="settings_wear_play_button_animation_subtitle">音乐播放时播放按钮周围持续旋转的圆环</string>
 </resources>

--- a/app/src/main/res/values/strings_library.xml
+++ b/app/src/main/res/values/strings_library.xml
@@ -265,9 +265,12 @@
 
     <!-- Watch Transfer Dialog + Foreground Service -->
     <string name="watch_transfer_action_cancel">Cancel transfer</string>
+    <string name="watch_transfer_batch_failed_count">%1$d songs failed</string>
+    <string name="watch_transfer_batch_progress">%1$d of %2$d songs</string>
     <string name="watch_transfer_bytes_progress">%1$s / %2$s</string>
     <string name="watch_transfer_channel_description">Shows live progress for phone-to-watch music transfers</string>
     <string name="watch_transfer_channel_name">Watch transfers</string>
+    <string name="watch_transfer_current_song">Sending: %1$s</string>
     <string name="watch_transfer_dialog_title">Sending to Watch</string>
     <string name="watch_transfer_status_cancelled">Cancelled</string>
     <string name="watch_transfer_status_cancelled_service">Transfer cancelled</string>
@@ -281,6 +284,7 @@
     <string name="watch_transfer_status_preparing_service">Preparing watch transfer</string>
     <string name="watch_transfer_status_preparing_transfer">Preparing transfer…</string>
     <string name="watch_transfer_status_sending_n_to_watch">Sending %1$d songs to watch</string>
+    <string name="watch_transfer_status_sending_playlist_to_watch">Sending \"%1$s\" to watch</string>
     <string name="watch_transfer_status_sending_to_watch">Sending to watch</string>
     <string name="watch_transfer_status_starting">Starting transfer…</string>
     <string name="watch_transfer_status_starting_short">Starting</string>

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -126,6 +126,19 @@
     <string name="playlist_cd_remove_songs">Remove songs</string>
     <string name="playlist_action_reorder_songs">Reorder</string>
     <string name="playlist_cd_reorder_songs">Reorder songs</string>
+    <string name="playlist_action_send_to_watch">Send to Watch</string>
+    <string name="playlist_action_update_on_watch">Update on Watch</string>
+    <string name="playlist_cd_send_to_watch">Send playlist to watch</string>
+    <string name="playlist_send_to_watch_dialog_title">Send \"%1$s\" to your watch?</string>
+    <string name="playlist_send_to_watch_dialog_update_title">Update \"%1$s\" on your watch?</string>
+    <string name="playlist_send_to_watch_dialog_pending_songs">%1$d of %2$d songs to send</string>
+    <string name="playlist_send_to_watch_dialog_all_songs">%1$d songs</string>
+    <string name="playlist_send_to_watch_dialog_estimate">%1$s · about %2$s</string>
+    <string name="playlist_send_to_watch_dialog_confirm">Send</string>
+    <string name="playlist_send_to_watch_dialog_update_confirm">Update</string>
+    <string name="playlist_send_to_watch_dialog_watch_unavailable">No watch connected</string>
+    <string name="playlist_watch_transfer_started_toast">Sending \"%1$s\" to your watch</string>
+    <string name="playlist_watch_transfer_start_failed_toast">Couldn\'t start the transfer: %1$s</string>
 
     <!-- EditTransitionScreen -->
     <string name="transition_title_global">Global transitions</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -23,6 +23,8 @@
     <string name="settings_category_accounts_subtitle">Manage Telegram, Google Drive, NetEase, and more services</string>
     <string name="settings_category_about_title">About</string>
     <string name="settings_category_about_subtitle">App info, version, and credits</string>
+    <string name="settings_category_wear_title">Watch</string>
+    <string name="settings_category_wear_subtitle">Performance options for offline playback on your watch</string>
 
     <!-- Common toggles / labels used in ThemeSelectorItem maps -->
     <string name="settings_label_on">On</string>
@@ -655,4 +657,14 @@
     <string name="settings_volume_section">Volume</string>
     <string name="settings_pause_on_volume_zero">Pause when volume reaches zero</string>
     <string name="settings_pause_on_volume_zero_desc">Automatically pause playback when the volume is set to 0</string>
+
+    <!-- Watch category -->
+    <string name="settings_wear_performance_section">Performance</string>
+    <string name="settings_wear_performance_scope_note">These only apply when your watch plays music on its own, without the phone connected. Controlling phone playback from the watch always shows the full experience.</string>
+    <string name="settings_wear_show_album_art_title">Show album art</string>
+    <string name="settings_wear_show_album_art_subtitle">Turn off to save memory on the watch — biggest impact of the three</string>
+    <string name="settings_wear_dynamic_color_title">Dynamic color</string>
+    <string name="settings_wear_dynamic_color_subtitle">Tint the watch UI from each song\'s artwork</string>
+    <string name="settings_wear_play_button_animation_title">Play button animation</string>
+    <string name="settings_wear_play_button_animation_subtitle">Continuous spinning ring around the play button while music plays</string>
 </resources>

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStoreTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStoreTest.kt
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test
  * `Dispatchers.Default` scope after a fixed real-time delay — asserting on it here would mean
  * either a real sleep, which `GEN-TEST-04` rules out, or refactoring the store's scope handling,
  * which is out of scope for this change). Every test below only asserts on state transitions that
- * are visible synchronously.
+ * are visible synchronously. The awaiting-watch-ack timeout runs on that same scope and is
+ * excluded for the same reason — it's covered by device testing instead.
  */
 class PhoneWatchTransferStateStoreTest {
 
@@ -44,6 +45,23 @@ class PhoneWatchTransferStateStoreTest {
     fun `progress is zero when totalBytes is not yet known`() {
         val state = PhoneWatchTransferState(requestId = "r1", songId = "s1", bytesTransferred = 0L, totalBytes = 0L)
         assertThat(state.progress).isEqualTo(0f)
+    }
+
+    @Test
+    fun `awaiting-watch-ack is recorded as a live, non-terminal state`() {
+        store.markRequested(requestId = "r1", songId = "s1")
+        store.markProgress(
+            requestId = "r1",
+            songId = "s1",
+            bytesTransferred = 100L,
+            totalBytes = 100L,
+            status = WearTransferProgress.STATUS_AWAITING_WATCH_ACK,
+        )
+
+        // The phone is waiting on the watch's own write-complete report here, so the entry must
+        // stay visible (the notification still shows the song) and must not be read as finished.
+        assertThat(store.transfers.value["r1"]?.status)
+            .isEqualTo(WearTransferProgress.STATUS_AWAITING_WATCH_ACK)
     }
 
     @Test

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStoreTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStoreTest.kt
@@ -94,6 +94,44 @@ class PhoneWatchTransferStateStoreTest {
     }
 
     @Test
+    fun `the watch's own report replaces what this phone believed it had`() {
+        store.retainReachableWatchNodes(setOf("node-1"))
+        store.markSongPresentOnWatch("node-1", "s1")
+
+        // The watch app was reinstalled, so it now reports an empty library. Anything this phone
+        // recorded from its own past transfers has to give way to that.
+        store.updateWatchLibrary(nodeId = "node-1", songIds = emptySet(), playlistIds = emptySet())
+
+        assertThat(store.watchSongIds.value).isEmpty()
+        assertThat(store.isSongSavedOnAllReachableWatches("s1")).isFalse()
+    }
+
+    @Test
+    fun `playlist presence comes from the watch, not from its songs being there`() {
+        store.retainReachableWatchNodes(setOf("node-1"))
+        store.updateWatchLibrary(
+            nodeId = "node-1",
+            songIds = setOf("shared-song"),
+            playlistIds = setOf("p-sent"),
+        )
+
+        assertThat(store.isPlaylistOnAnyReachableWatch("p-sent")).isTrue()
+        // Shares a song with p-sent, but was never itself synced to the watch.
+        assertThat(store.isPlaylistOnAnyReachableWatch("p-never-sent")).isFalse()
+    }
+
+    @Test
+    fun `a playlist recorded for a node that dropped out stops counting as present`() {
+        store.retainReachableWatchNodes(setOf("node-1"))
+        store.markPlaylistPresentOnWatch("node-1", "p1")
+
+        store.retainReachableWatchNodes(setOf("node-2"))
+
+        assertThat(store.isPlaylistOnAnyReachableWatch("p1")).isFalse()
+        assertThat(store.watchPlaylistIds.value).isEmpty()
+    }
+
+    @Test
     fun `isSongSavedOnAllReachableWatches is false when there are no reachable watches`() {
         assertThat(store.isSongSavedOnAllReachableWatches("s1")).isFalse()
     }

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStoreTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PhoneWatchTransferStateStoreTest.kt
@@ -1,0 +1,249 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.shared.WearTransferProgress
+import org.junit.jupiter.api.Test
+
+/**
+ * Doesn't exercise the store's terminal-state cleanup (it runs on an internal, non-injectable
+ * `Dispatchers.Default` scope after a fixed real-time delay — asserting on it here would mean
+ * either a real sleep, which `GEN-TEST-04` rules out, or refactoring the store's scope handling,
+ * which is out of scope for this change). Every test below only asserts on state transitions that
+ * are visible synchronously.
+ */
+class PhoneWatchTransferStateStoreTest {
+
+    private val store = PhoneWatchTransferStateStore()
+
+    // --- Per-song transfers (existing, previously untested) ---
+
+    @Test
+    fun `markRequested creates a transferring entry`() {
+        store.markRequested(requestId = "r1", songId = "s1", songTitle = "Song")
+
+        val state = store.transfers.value["r1"]
+        assertThat(state?.songId).isEqualTo("s1")
+        assertThat(state?.status).isEqualTo(WearTransferProgress.STATUS_TRANSFERRING)
+    }
+
+    @Test
+    fun `markProgress keeps the highest bytesTransferred seen, never regresses`() {
+        store.markProgress("r1", "s1", bytesTransferred = 500L, totalBytes = 1000L, status = WearTransferProgress.STATUS_TRANSFERRING)
+        store.markProgress("r1", "s1", bytesTransferred = 200L, totalBytes = 1000L, status = WearTransferProgress.STATUS_TRANSFERRING)
+
+        assertThat(store.transfers.value["r1"]?.bytesTransferred).isEqualTo(500L)
+    }
+
+    @Test
+    fun `progress is the clamped ratio of bytesTransferred to totalBytes`() {
+        val state = PhoneWatchTransferState(requestId = "r1", songId = "s1", bytesTransferred = 50L, totalBytes = 100L)
+        assertThat(state.progress).isEqualTo(0.5f)
+    }
+
+    @Test
+    fun `progress is zero when totalBytes is not yet known`() {
+        val state = PhoneWatchTransferState(requestId = "r1", songId = "s1", bytesTransferred = 0L, totalBytes = 0L)
+        assertThat(state.progress).isEqualTo(0f)
+    }
+
+    @Test
+    fun `markCancelled marks an existing transfer as cancelled without creating a new one`() {
+        store.markRequested("r1", "s1")
+        store.markCancelled("r1", error = "user cancelled")
+
+        val state = store.transfers.value["r1"]
+        assertThat(state?.status).isEqualTo(WearTransferProgress.STATUS_CANCELLED)
+        assertThat(state?.error).isEqualTo("user cancelled")
+    }
+
+    @Test
+    fun `markCancelled for an unknown requestId is a no-op`() {
+        store.markCancelled("unknown")
+        assertThat(store.transfers.value).isEmpty()
+    }
+
+    @Test
+    fun `markSongPresentOnWatch and isSongSavedOnAllReachableWatches agree once every reachable node has it`() {
+        store.retainReachableWatchNodes(setOf("node-1", "node-2"))
+
+        assertThat(store.isSongSavedOnAllReachableWatches("s1")).isFalse()
+
+        store.markSongPresentOnWatch("node-1", "s1")
+        assertThat(store.isSongSavedOnAllReachableWatches("s1")).isFalse()
+
+        store.markSongPresentOnWatch("node-2", "s1")
+        assertThat(store.isSongSavedOnAllReachableWatches("s1")).isTrue()
+    }
+
+    @Test
+    fun `isSongSavedOnAllReachableWatches is false when there are no reachable watches`() {
+        assertThat(store.isSongSavedOnAllReachableWatches("s1")).isFalse()
+    }
+
+    @Test
+    fun `retainReachableWatchNodes forgets song presence recorded for a node that dropped out`() {
+        store.retainReachableWatchNodes(setOf("node-1"))
+        store.markSongPresentOnWatch("node-1", "s1")
+        assertThat(store.isSongSavedOnAllReachableWatches("s1")).isTrue()
+
+        store.retainReachableWatchNodes(setOf("node-2"))
+
+        assertThat(store.watchSongIds.value).isEmpty()
+    }
+
+    // --- Playlist batch transfers ---
+
+    @Test
+    fun `markBatchStarted publishes the initial aggregate state`() {
+        store.markBatchStarted("b1", "playlist-1", "Running mix", totalSongCount = 20)
+
+        val batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.playlistName).isEqualTo("Running mix")
+        assertThat(batch?.totalSongCount).isEqualTo(20)
+        assertThat(batch?.completedSongCount).isEqualTo(0)
+        assertThat(batch?.failedSongCount).isEqualTo(0)
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_TRANSFERRING)
+    }
+
+    @Test
+    fun `song lifecycle updates activeRequestId, progress and completed count`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 2)
+
+        store.markBatchSongStarted("b1", activeRequestId = "r1", songTitle = "Track 1")
+        var batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.activeRequestId).isEqualTo("r1")
+        assertThat(batch?.currentSongTitle).isEqualTo("Track 1")
+
+        store.markBatchSongProgress("b1", WearTransferProgress.STATUS_TRANSFERRING, progress = 0.6f)
+        batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.currentSongProgress).isEqualTo(0.6f)
+
+        store.markBatchSongCompleted("b1")
+        batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.completedSongCount).isEqualTo(1)
+        assertThat(batch?.activeRequestId).isNull()
+        assertThat(batch?.currentSongProgress).isEqualTo(0f)
+    }
+
+    @Test
+    fun `markBatchSongProgress clamps out-of-range values`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 1)
+
+        store.markBatchSongProgress("b1", WearTransferProgress.STATUS_TRANSFERRING, progress = 1.5f)
+        assertThat(store.batchTransfers.value["b1"]?.currentSongProgress).isEqualTo(1f)
+
+        store.markBatchSongProgress("b1", WearTransferProgress.STATUS_TRANSFERRING, progress = -0.5f)
+        assertThat(store.batchTransfers.value["b1"]?.currentSongProgress).isEqualTo(0f)
+    }
+
+    @Test
+    fun `markBatchSongFailed increments the failure count and records the reason`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 1)
+
+        store.markBatchSongFailed("b1", errorMessage = WearTransferProgress.ERROR_CODE_TIMED_OUT)
+
+        val batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.failedSongCount).isEqualTo(1)
+        assertThat(batch?.errorMessage).isEqualTo(WearTransferProgress.ERROR_CODE_TIMED_OUT)
+    }
+
+    @Test
+    fun `markBatchSongFailed without a new reason keeps the previous one`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 2)
+        store.markBatchSongFailed("b1", errorMessage = "first failure")
+
+        store.markBatchSongFailed("b1", errorMessage = null)
+
+        assertThat(store.batchTransfers.value["b1"]?.errorMessage).isEqualTo("first failure")
+        assertThat(store.batchTransfers.value["b1"]?.failedSongCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `markBatchCompleted sets the terminal status and clears the active song`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 1)
+        store.markBatchSongStarted("b1", "r1", "Track")
+
+        store.markBatchCompleted("b1")
+
+        val batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_COMPLETED)
+        assertThat(batch?.activeRequestId).isNull()
+    }
+
+    @Test
+    fun `markBatchFailed records the error message and sets the terminal status`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 1)
+
+        store.markBatchFailed("b1", "No reachable watch with PixelPlay")
+
+        val batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_FAILED)
+        assertThat(batch?.errorMessage).isEqualTo("No reachable watch with PixelPlay")
+    }
+
+    @Test
+    fun `markBatchCancelled sets the cancelled status and keeps the song counts so far`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 3)
+        store.markBatchSongCompleted("b1")
+
+        store.markBatchCancelled("b1")
+
+        val batch = store.batchTransfers.value["b1"]
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_CANCELLED)
+        assertThat(batch?.completedSongCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `updates for an unknown batchId are ignored rather than creating a partial entry`() {
+        store.markBatchSongCompleted("never-started")
+        store.markBatchSongProgress("never-started", WearTransferProgress.STATUS_TRANSFERRING, 0.5f)
+        store.markBatchCompleted("never-started")
+
+        assertThat(store.batchTransfers.value).isEmpty()
+    }
+
+    @Test
+    fun `processedSongCount sums completed and failed songs`() {
+        store.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 5)
+        store.markBatchSongCompleted("b1")
+        store.markBatchSongCompleted("b1")
+        store.markBatchSongFailed("b1")
+
+        assertThat(store.batchTransfers.value["b1"]?.processedSongCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `two concurrent batches keep independent state`() {
+        store.markBatchStarted("b1", "p1", "Playlist 1", totalSongCount = 2)
+        store.markBatchStarted("b2", "p2", "Playlist 2", totalSongCount = 5)
+
+        store.markBatchSongCompleted("b1")
+
+        assertThat(store.batchTransfers.value["b1"]?.completedSongCount).isEqualTo(1)
+        assertThat(store.batchTransfers.value["b2"]?.completedSongCount).isEqualTo(0)
+    }
+
+    // --- isAnyWatchPaired: distinct from reachableWatchNodeIds (paired vs. reachable now) ---
+
+    @Test
+    fun `isAnyWatchPaired defaults to false`() {
+        assertThat(store.isAnyWatchPaired.value).isFalse()
+    }
+
+    @Test
+    fun `setAnyWatchPaired true flips the flag`() {
+        store.setAnyWatchPaired(true)
+
+        assertThat(store.isAnyWatchPaired.value).isTrue()
+    }
+
+    @Test
+    fun `setAnyWatchPaired is independent of reachableWatchNodeIds`() {
+        store.setAnyWatchPaired(true)
+        store.retainReachableWatchNodes(emptySet())
+
+        // A paired watch that's simply out of range right now shouldn't un-pair itself.
+        assertThat(store.isAnyWatchPaired.value).isTrue()
+        assertThat(store.reachableWatchNodeIds.value).isEmpty()
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PlaylistBatchTransferPersistenceTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PlaylistBatchTransferPersistenceTest.kt
@@ -1,0 +1,117 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.google.common.truth.Truth.assertThat
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PlaylistBatchTransferPersistenceTest {
+
+    // DataStore's internal write-actor needs a CoroutineScope that outlives any single test
+    // method's own `runTest {}` block — a `runTest`-scoped `backgroundScope` gets cancelled the
+    // moment that particular runTest call returns, which would tear this down mid-test if it were
+    // built in @BeforeEach's own runTest instead of here.
+    private lateinit var dataStoreScope: CoroutineScope
+    private lateinit var tempDir: Path
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var persistence: PlaylistBatchTransferPersistence
+
+    @BeforeEach
+    fun setUp() {
+        tempDir = Files.createTempDirectory("playlist-batch-persistence-test")
+        dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = dataStoreScope,
+            produceFile = { tempDir.resolve("settings.preferences_pb").toFile() },
+        )
+        persistence = PlaylistBatchTransferPersistence(dataStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        dataStoreScope.cancel()
+        tempDir.toFile().deleteRecursively()
+    }
+
+    private fun intent(
+        batchId: String = "batch-1",
+        playlistId: String = "p1",
+        songIds: List<String> = listOf("s1", "s2"),
+    ) = PersistedPlaylistBatchIntent(
+        batchId = batchId,
+        playlistId = playlistId,
+        playlistName = "Road trip",
+        songIds = songIds,
+        requestedAtMillis = 1_000L,
+    )
+
+    @Test
+    fun `nothing persisted returns null`() = runTest {
+        assertThat(persistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `save then get round-trips the intent`() = runTest {
+        val saved = intent()
+        persistence.saveInFlightBatch(saved)
+
+        assertThat(persistence.getInFlightBatch()).isEqualTo(saved)
+    }
+
+    @Test
+    fun `saving a second batch overwrites the first`() = runTest {
+        persistence.saveInFlightBatch(intent(batchId = "batch-1", playlistId = "p1"))
+        persistence.saveInFlightBatch(intent(batchId = "batch-2", playlistId = "p2"))
+
+        assertThat(persistence.getInFlightBatch()?.batchId).isEqualTo("batch-2")
+    }
+
+    @Test
+    fun `clearing with the matching batchId removes it`() = runTest {
+        persistence.saveInFlightBatch(intent(batchId = "batch-1"))
+
+        persistence.clearInFlightBatch("batch-1")
+
+        assertThat(persistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `clearing with a stale batchId is a no-op, so a newer batch survives`() = runTest {
+        persistence.saveInFlightBatch(intent(batchId = "batch-1"))
+        persistence.saveInFlightBatch(intent(batchId = "batch-2"))
+
+        // Batch 1's own coordinator finally reaches its terminal state and tries to clear itself,
+        // but batch 2 already overwrote the stored intent — must not clear batch 2's.
+        persistence.clearInFlightBatch("batch-1")
+
+        assertThat(persistence.getInFlightBatch()?.batchId).isEqualTo("batch-2")
+    }
+
+    @Test
+    fun `clearing when nothing is stored does not throw`() = runTest {
+        persistence.clearInFlightBatch("batch-1")
+
+        assertThat(persistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `malformed stored data is treated as nothing persisted, not a crash`() = runTest {
+        dataStore.edit { preferences ->
+            preferences[stringPreferencesKey("wear_playlist_batch_in_flight_v1")] = "{not valid json"
+        }
+
+        assertThat(persistence.getInFlightBatch()).isNull()
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinatorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinatorTest.kt
@@ -525,7 +525,32 @@ class PlaylistWatchTransferCoordinatorTest {
         coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
         advanceUntilIdle()
 
+        // A brand-new request that finds no watch is simply a failed request: the user saw it
+        // fail, so it must not come back to life on some later launch.
         assertThat(batchPersistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `a resumed batch that finds no reachable watch keeps its intent for the next launch`() = runTest {
+        stubReachableNodes()
+        song("s1")
+        val coordinator = buildCoordinator(this)
+        batchPersistence.saveInFlightBatch(
+            PersistedPlaylistBatchIntent(
+                batchId = "orphaned-batch",
+                playlistId = "p1",
+                playlistName = "Playlist",
+                songIds = listOf("s1"),
+                requestedAtMillis = System.currentTimeMillis(),
+            )
+        )
+
+        coordinator.resumePersistedBatchIfNeeded()
+        advanceUntilIdle()
+
+        // The watch being out of range at a cold start is exactly what the persistence is for;
+        // dropping the intent here would lose the interrupted transfer for good.
+        assertThat(batchPersistence.getInFlightBatch()?.playlistId).isEqualTo("p1")
     }
 
     @Test
@@ -576,7 +601,7 @@ class PlaylistWatchTransferCoordinatorTest {
                 playlistId = "p1",
                 playlistName = "Playlist",
                 songIds = listOf("s1", "s2"),
-                requestedAtMillis = 0L,
+                requestedAtMillis = System.currentTimeMillis(),
             )
         )
 
@@ -585,5 +610,107 @@ class PlaylistWatchTransferCoordinatorTest {
 
         assertThat(transferredSongIdsInOrder).containsExactly("s1", "s2").inOrder()
         coVerify { wearPhoneTransferSender.refreshWatchLibraryState() }
+    }
+
+    @Test
+    fun `a resumed intent carries the original request time forward, so it can still age out`() = runTest {
+        // No watch in range, so the resumed batch stops early and leaves the intent in place —
+        // the only state in which there's still a persisted timestamp to inspect.
+        stubReachableNodes()
+        song("s1")
+        val coordinator = buildCoordinator(this)
+        val originalRequestedAt = System.currentTimeMillis() - 1_000L
+        batchPersistence.saveInFlightBatch(
+            PersistedPlaylistBatchIntent(
+                batchId = "orphaned-batch",
+                playlistId = "p1",
+                playlistName = "Playlist",
+                songIds = listOf("s1"),
+                requestedAtMillis = originalRequestedAt,
+            )
+        )
+
+        coordinator.resumePersistedBatchIfNeeded()
+        advanceUntilIdle()
+
+        // Re-stamping this "now" on every resume would make the intent immortal: its age could
+        // then never reach the cutoff that discards abandoned transfers.
+        assertThat(batchPersistence.getInFlightBatch()?.requestedAtMillis).isEqualTo(originalRequestedAt)
+    }
+
+    @Test
+    fun `an intent older than the resume cutoff is discarded instead of resumed`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        val coordinator = buildCoordinator(this)
+        batchPersistence.saveInFlightBatch(
+            PersistedPlaylistBatchIntent(
+                batchId = "ancient-batch",
+                playlistId = "p1",
+                playlistName = "Playlist",
+                songIds = listOf("s1"),
+                requestedAtMillis = System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000,
+            )
+        )
+
+        coordinator.resumePersistedBatchIfNeeded()
+        advanceUntilIdle()
+
+        assertThat(transferredSongIdsInOrder).isEmpty()
+        assertThat(batchPersistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `a song the watch already has counts as transferred, not as a failure`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1")
+        val coordinator = buildCoordinator(this)
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            transferredSongIdsInOrder += songId
+            transferStateStore.markProgress(
+                requestId = requestId,
+                songId = songId,
+                bytesTransferred = 0L,
+                totalBytes = 0L,
+                status = WearTransferProgress.STATUS_FAILED,
+                error = WearTransferProgress.ERROR_ALREADY_ON_WATCH,
+            )
+        }
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.completedSongCount).isEqualTo(1)
+        assertThat(batch?.failedSongCount).isEqualTo(0)
+        // Offered exactly once: the old behaviour read the rejection as a failure and re-transcoded
+        // and re-offered the very same song before reporting it to the user as failed.
+        assertThat(transferredSongIdsInOrder).containsExactly("s1")
+        assertThat(transferStateStore.isSongSavedOnAllReachableWatches("s1")).isTrue()
+    }
+
+    @Test
+    fun `a batch cancelled before it starts is reported as cancelled, not completed`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        val coordinator = buildCoordinator(this)
+
+        // Cancel lands before runBatchTransfer has had a chance to register the batch — the user
+        // tapping send and then immediately cancel.
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        coordinator.cancelPlaylistTransfer(batchId)
+        advanceUntilIdle()
+
+        assertThat(transferStateStore.batchTransfers.value[batchId]?.status)
+            .isEqualTo(WearTransferProgress.STATUS_CANCELLED)
     }
 }

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinatorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/PlaylistWatchTransferCoordinatorTest.kt
@@ -1,0 +1,589 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import android.app.Application
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.CapabilityInfo
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.Node
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.repository.MusicRepository
+import com.theveloper.pixelplay.shared.WearDataPaths
+import com.theveloper.pixelplay.shared.WearPlaylistSync
+import com.theveloper.pixelplay.shared.WearPlaylistSyncAck
+import com.theveloper.pixelplay.shared.WearTransferProgress
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.nio.file.Files
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * capabilityClient/messageClient are constructor-injected into the coordinator (unlike most of
+ * the wear/ package, which resolves them via `Wearable.getXClient(application)` internally) so
+ * they can be faked here directly — both are non-final abstract GMS classes, so MockK subclasses
+ * them with no inline-mocking agent involved. Mocking `Wearable`'s static factory methods instead
+ * would need that agent, which hangs indefinitely under this environment's sandboxing.
+ */
+class PlaylistWatchTransferCoordinatorTest {
+
+    private val application = mockk<Application>(relaxed = true)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val musicRepository = mockk<MusicRepository>()
+    private val watchAudioTranscoder = mockk<WatchAudioTranscoder>()
+    private val directTransferCoordinator = mockk<PhoneDirectWatchTransferCoordinator>(relaxed = true)
+    private val wearPhoneTransferSender = mockk<WearPhoneTransferSender>(relaxed = true)
+    private val transferStateStore = PhoneWatchTransferStateStore()
+    private val capabilityClient = mockk<CapabilityClient>()
+    private val messageClient = mockk<MessageClient>()
+
+    private val transferredSongIdsInOrder = mutableListOf<String>()
+    private lateinit var tempDir: java.nio.file.Path
+    private lateinit var batchPersistence: PlaylistBatchTransferPersistence
+
+    @BeforeEach
+    fun setUp() {
+        tempDir = Files.createTempDirectory("playlist-watch-transfer-coordinator-test")
+        // Default: no song needs transcoding. transcodeIfNeeded is what the coordinator actually
+        // calls — requiresTranscoding lives inside it and is never invoked directly by the
+        // coordinator, so stubbing that instead would silently test nothing.
+        coEvery { watchAudioTranscoder.transcodeIfNeeded(any(), any(), any()) } returns
+            WatchAudioTranscoder.TranscodeResult.Passthrough
+        every { watchAudioTranscoder.cleanup(any()) } just Runs
+
+        // Tasks.forResult builds a real, already-completed Task — play-services-tasks has no
+        // Android framework dependency for this, so it resolves correctly off-device. Playlist
+        // syncs additionally auto-ack (simulating a healthy watch) so every existing test here
+        // keeps its original one-send-per-node behavior; tests that care about the ack-timeout/
+        // retry path override this locally.
+        every { messageClient.sendMessage(any(), any(), any()) } answers {
+            autoAckIfPlaylistSync(thirdArg())
+            Tasks.forResult(0)
+        }
+
+        every { musicRepository.getSongsByIds(any()) } answers {
+            val requestedIds = firstArg<List<String>>()
+            flowOf(requestedIds.mapNotNull { id -> songsById[id] })
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tempDir.toFile().deleteRecursively()
+    }
+
+    private val songsById = mutableMapOf<String, Song>()
+
+    private fun song(id: String, title: String = "Song $id"): Song {
+        val song = Song.emptySong().copy(id = id, title = title)
+        songsById[id] = song
+        return song
+    }
+
+    /** Decodes [bytes] as a [WearPlaylistSync] and, if it carries a requestId, immediately acks it. */
+    private fun autoAckIfPlaylistSync(bytes: ByteArray) {
+        val sync = runCatching {
+            json.decodeFromString<WearPlaylistSync>(String(bytes, Charsets.UTF_8))
+        }.getOrNull() ?: return
+        if (sync.requestId.isEmpty()) return
+        transferStateStore.onPlaylistSyncAckReceived(
+            WearPlaylistSyncAck(playlistId = sync.playlistId, requestId = sync.requestId)
+        )
+    }
+
+    private fun stubReachableNodes(vararg nodeIds: String) {
+        val nodes = nodeIds.map { nodeId -> mockk<Node> { every { id } returns nodeId } }.toSet()
+        val capabilityInfo = mockk<CapabilityInfo> { every { this@mockk.nodes } returns nodes }
+        every { capabilityClient.getCapability(any(), any()) } returns Tasks.forResult(capabilityInfo)
+    }
+
+    /** Every startTransferToWatch call resolves to [status] as soon as it's invoked. */
+    private fun stubTransfersResolveTo(status: String) {
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(),
+                requestId = any(),
+                songId = any(),
+                transferMode = any(),
+                startPositionMs = any(),
+                autoPlay = any(),
+                audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            transferredSongIdsInOrder += songId
+            transferStateStore.markProgress(
+                requestId = requestId,
+                songId = songId,
+                bytesTransferred = 100L,
+                totalBytes = 100L,
+                status = status,
+            )
+        }
+    }
+
+    private fun buildCoordinator(scope: kotlinx.coroutines.CoroutineScope): PlaylistWatchTransferCoordinator {
+        batchPersistence = PlaylistBatchTransferPersistence(
+            dataStore = PreferenceDataStoreFactory.create(
+                scope = scope,
+                produceFile = { tempDir.resolve("settings.preferences_pb").toFile() },
+            ),
+        )
+        return PlaylistWatchTransferCoordinator(
+            application = application,
+            musicRepository = musicRepository,
+            watchAudioTranscoder = watchAudioTranscoder,
+            directTransferCoordinator = directTransferCoordinator,
+            wearPhoneTransferSender = wearPhoneTransferSender,
+            transferStateStore = transferStateStore,
+            batchPersistence = batchPersistence,
+            capabilityClient = capabilityClient,
+            messageClient = messageClient,
+            scope = scope,
+        )
+    }
+
+    @Test
+    fun `an empty playlist does not start a batch`() = runTest {
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Empty", emptyList())
+        advanceUntilIdle()
+
+        assertThat(transferStateStore.batchTransfers.value).isEmpty()
+        verify(exactly = 0) { directTransferCoordinator.startTransferToWatch(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `fails the batch when no watch is reachable`() = runTest {
+        stubReachableNodes()
+        song("s1")
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_FAILED)
+    }
+
+    @Test
+    fun `transfers songs in playlist order`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s3"); song("s1"); song("s2")
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s3", "s1", "s2"))
+        advanceUntilIdle()
+
+        assertThat(transferredSongIdsInOrder).containsExactly("s3", "s1", "s2").inOrder()
+    }
+
+    @Test
+    fun `the playlist sync sent to the watch carries song titles in the same order as ids`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s3", title = "Third"); song("s1", title = "First"); song("s2", title = "Second")
+        val syncPayloads = mutableListOf<WearPlaylistSync>()
+        every { messageClient.sendMessage(any(), WearDataPaths.PLAYLIST_SYNC, any()) } answers {
+            val bytes = thirdArg<ByteArray>()
+            syncPayloads += json.decodeFromString<WearPlaylistSync>(String(bytes, Charsets.UTF_8))
+            autoAckIfPlaylistSync(bytes)
+            Tasks.forResult(0)
+        }
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s3", "s1", "s2"))
+        advanceUntilIdle()
+
+        assertThat(syncPayloads).hasSize(1)
+        assertThat(syncPayloads.single().songIds).containsExactly("s3", "s1", "s2").inOrder()
+        assertThat(syncPayloads.single().songTitles).containsExactly("Third", "First", "Second").inOrder()
+    }
+
+    @Test
+    fun `songs already saved on every reachable watch are not re-transferred`() = runTest {
+        stubReachableNodes("node-1")
+        transferStateStore.retainReachableWatchNodes(setOf("node-1"))
+        transferStateStore.markSongPresentOnWatch("node-1", "already-there")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("already-there"); song("pending")
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("already-there", "pending"))
+        advanceUntilIdle()
+
+        assertThat(transferredSongIdsInOrder).containsExactly("pending")
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.completedSongCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `one song failing does not abort the rest of the batch`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1"); song("s2"); song("s3")
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            transferredSongIdsInOrder += songId
+            // s2 fails on every attempt, including its retry (see the dedicated retry tests
+            // below) — this test is only about the batch surviving a song that never recovers.
+            val status = if (songId == "s2") WearTransferProgress.STATUS_FAILED else WearTransferProgress.STATUS_COMPLETED
+            transferStateStore.markProgress(requestId, songId, 0L, 0L, status)
+        }
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1", "s2", "s3"))
+        advanceUntilIdle()
+
+        // s2 appears twice: the first attempt and its retry.
+        assertThat(transferredSongIdsInOrder).containsExactly("s1", "s2", "s2", "s3").inOrder()
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.completedSongCount).isEqualTo(2)
+        assertThat(batch?.failedSongCount).isEqualTo(1)
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_COMPLETED)
+    }
+
+    @Test
+    fun `a song that fails once but succeeds on retry counts as completed`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1")
+        var attempt = 0
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            attempt += 1
+            val status = if (attempt == 1) WearTransferProgress.STATUS_FAILED else WearTransferProgress.STATUS_COMPLETED
+            transferStateStore.markProgress(requestId, songId, 0L, 0L, status)
+        }
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        assertThat(attempt).isEqualTo(2)
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.completedSongCount).isEqualTo(1)
+        assertThat(batch?.failedSongCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `a song failing twice in a row is only retried once, not indefinitely`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1")
+        var attempts = 0
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            attempts += 1
+            transferStateStore.markProgress(requestId, songId, 0L, 0L, WearTransferProgress.STATUS_FAILED)
+        }
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        assertThat(attempts).isEqualTo(2)
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.failedSongCount).isEqualTo(1)
+        assertThat(batch?.completedSongCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `cancelling during the backoff window skips the retry`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1")
+        val coordinator = buildCoordinator(this)
+        lateinit var batchId: String
+
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            transferredSongIdsInOrder += songId
+            coordinator.cancelPlaylistTransfer(batchId)
+            transferStateStore.markProgress(requestId, songId, 0L, 0L, WearTransferProgress.STATUS_FAILED)
+        }
+
+        batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        assertThat(transferredSongIdsInOrder).containsExactly("s1")
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_CANCELLED)
+    }
+
+    @Test
+    fun `cancelling a batch stops remaining songs from being transferred`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1"); song("s2"); song("s3")
+        val coordinator = buildCoordinator(this)
+        lateinit var batchId: String
+
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            transferredSongIdsInOrder += songId
+            if (songId == "s1") {
+                // Cancel mid-batch, right after the first song starts, before it resolves.
+                coordinator.cancelPlaylistTransfer(batchId)
+            }
+            transferStateStore.markProgress(requestId, songId, 0L, 0L, WearTransferProgress.STATUS_COMPLETED)
+        }
+
+        batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1", "s2", "s3"))
+        advanceUntilIdle()
+
+        assertThat(transferredSongIdsInOrder).containsExactly("s1")
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_CANCELLED)
+    }
+
+    @Test
+    fun `a song whose transfer never reaches a terminal state is failed as timed out`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1")
+        // directTransferCoordinator is a relaxed mock here — startTransferToWatch is a no-op and
+        // never pushes a terminal state into transferStateStore, simulating a watch that never
+        // acknowledges the transfer.
+        val coordinator = buildCoordinator(this)
+        coordinator.songTransferAwaitTimeoutMs = 50L
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.failedSongCount).isEqualTo(1)
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_COMPLETED)
+    }
+
+    @Test
+    fun `sends the song to every reachable node, counting it as one completed song`() = runTest {
+        stubReachableNodes("node-1", "node-2")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        verify(exactly = 2) {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        }
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.completedSongCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `a song missing from the library is counted as failed, not silently dropped`() = runTest {
+        stubReachableNodes("node-1")
+        // "missing" is never registered via song(), so musicRepository.getSongsByIds returns nothing for it.
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("missing"))
+        advanceUntilIdle()
+
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.failedSongCount).isEqualTo(1)
+        assertThat(batch?.completedSongCount).isEqualTo(0)
+    }
+
+    // --- Playlist sync reliability: ack + retry ---
+
+    @Test
+    fun `a playlist sync acked on the first attempt is sent only once`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        verify(exactly = 1) { messageClient.sendMessage(any(), WearDataPaths.PLAYLIST_SYNC, any()) }
+    }
+
+    @Test
+    fun `a playlist sync that's never acked is retried once, then given up on`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        // Overrides the auto-acking default stub — this node never acks, simulating the watch
+        // being mid-reconnect when both attempts go out.
+        every { messageClient.sendMessage(any(), WearDataPaths.PLAYLIST_SYNC, any()) } returns Tasks.forResult(0)
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        // One initial attempt plus exactly one retry — not retried indefinitely.
+        verify(exactly = 2) { messageClient.sendMessage(any(), WearDataPaths.PLAYLIST_SYNC, any()) }
+    }
+
+    @Test
+    fun `a playlist sync acked only on the retry stops after that retry`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        var attempt = 0
+        every { messageClient.sendMessage(any(), WearDataPaths.PLAYLIST_SYNC, any()) } answers {
+            attempt += 1
+            val bytes = thirdArg<ByteArray>()
+            if (attempt >= 2) autoAckIfPlaylistSync(bytes)
+            Tasks.forResult(0)
+        }
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        assertThat(attempt).isEqualTo(2)
+    }
+
+    @Test
+    fun `songs still transfer even when the playlist sync is never acked`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        every { messageClient.sendMessage(any(), WearDataPaths.PLAYLIST_SYNC, any()) } returns Tasks.forResult(0)
+        val coordinator = buildCoordinator(this)
+
+        val batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        // An unconfirmed playlist sync is a warning, not a batch failure — the song itself still
+        // lands on the watch, it just might not show up under the playlist until the next sync.
+        assertThat(transferredSongIdsInOrder).containsExactly("s1")
+        val batch = transferStateStore.batchTransfers.value[batchId]
+        assertThat(batch?.status).isEqualTo(WearTransferProgress.STATUS_COMPLETED)
+        assertThat(batch?.completedSongCount).isEqualTo(1)
+    }
+
+    // --- Persistence: resuming a batch interrupted by process death (PR7) ---
+
+    @Test
+    fun `a completed batch clears its persisted intent`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1")
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        assertThat(batchPersistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `a batch that fails with no reachable watch clears its persisted intent`() = runTest {
+        stubReachableNodes()
+        song("s1")
+        val coordinator = buildCoordinator(this)
+
+        coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1"))
+        advanceUntilIdle()
+
+        assertThat(batchPersistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `cancelling a batch clears its persisted intent`() = runTest {
+        stubReachableNodes("node-1")
+        song("s1"); song("s2")
+        val coordinator = buildCoordinator(this)
+        lateinit var batchId: String
+
+        every {
+            directTransferCoordinator.startTransferToWatch(
+                nodeId = any(), requestId = any(), songId = any(),
+                transferMode = any(), startPositionMs = any(), autoPlay = any(), audioOverride = any(),
+            )
+        } answers {
+            val requestId = secondArg<String>()
+            val songId = thirdArg<String>()
+            coordinator.cancelPlaylistTransfer(batchId)
+            transferStateStore.markProgress(requestId, songId, 0L, 0L, WearTransferProgress.STATUS_COMPLETED)
+        }
+
+        batchId = coordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1", "s2"))
+        advanceUntilIdle()
+
+        assertThat(batchPersistence.getInFlightBatch()).isNull()
+    }
+
+    @Test
+    fun `resuming with nothing persisted does not start a transfer`() = runTest {
+        val coordinator = buildCoordinator(this)
+
+        coordinator.resumePersistedBatchIfNeeded()
+        advanceUntilIdle()
+
+        assertThat(transferStateStore.batchTransfers.value).isEmpty()
+        verify(exactly = 0) { directTransferCoordinator.startTransferToWatch(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `resuming a persisted intent re-runs the transfer for the same playlist and songs`() = runTest {
+        stubReachableNodes("node-1")
+        stubTransfersResolveTo(WearTransferProgress.STATUS_COMPLETED)
+        song("s1"); song("s2")
+        val coordinator = buildCoordinator(this)
+        batchPersistence.saveInFlightBatch(
+            PersistedPlaylistBatchIntent(
+                batchId = "orphaned-batch",
+                playlistId = "p1",
+                playlistName = "Playlist",
+                songIds = listOf("s1", "s2"),
+                requestedAtMillis = 0L,
+            )
+        )
+
+        coordinator.resumePersistedBatchIfNeeded()
+        advanceUntilIdle()
+
+        assertThat(transferredSongIdsInOrder).containsExactly("s1", "s2").inOrder()
+        coVerify { wearPhoneTransferSender.refreshWatchLibraryState() }
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoderTest.kt
@@ -1,0 +1,61 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import android.app.Application
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.model.Song
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers [WatchAudioTranscoder.requiresTranscoding] only — the pure decision function. The actual
+ * encode path (`transcodeIfNeeded` / `runTransform`) drives a real [androidx.media3.transformer.Transformer],
+ * which needs a hardware encoder and a Looper thread; that's only verifiable on a device.
+ */
+class WatchAudioTranscoderTest {
+
+    // requiresTranscoding never touches these — a relaxed mock and any real dispatcher are enough.
+    private val transcoder = WatchAudioTranscoder(
+        application = mockk<Application>(relaxed = true),
+        mainDispatcher = Dispatchers.Unconfined,
+    )
+
+    private fun song(mimeType: String?, bitrate: Int?) =
+        Song.emptySong().copy(mimeType = mimeType, bitrate = bitrate)
+
+    @Test
+    fun `a lossless format requires transcoding regardless of bitrate`() {
+        assertThat(transcoder.requiresTranscoding(song("audio/flac", bitrate = 128_000))).isTrue()
+        assertThat(transcoder.requiresTranscoding(song("audio/flac", bitrate = null))).isTrue()
+    }
+
+    @Test
+    fun `a lossy source at or under the passthrough bitrate is sent as-is`() {
+        assertThat(transcoder.requiresTranscoding(song("audio/mpeg", bitrate = 128_000))).isFalse()
+    }
+
+    @Test
+    fun `a lossy source at exactly the passthrough bitrate boundary is sent as-is`() {
+        assertThat(transcoder.requiresTranscoding(song("audio/mpeg", bitrate = 256_000))).isFalse()
+    }
+
+    @Test
+    fun `a lossy source over the passthrough bitrate is transcoded down`() {
+        assertThat(transcoder.requiresTranscoding(song("audio/mpeg", bitrate = 320_000))).isTrue()
+    }
+
+    @Test
+    fun `unknown mimeType requires transcoding`() {
+        assertThat(transcoder.requiresTranscoding(song(mimeType = null, bitrate = 128_000))).isTrue()
+    }
+
+    @Test
+    fun `unknown bitrate requires transcoding even for an otherwise eligible lossy mimeType`() {
+        assertThat(transcoder.requiresTranscoding(song("audio/mpeg", bitrate = null))).isTrue()
+    }
+
+    @Test
+    fun `mimeType is matched case-insensitively`() {
+        assertThat(transcoder.requiresTranscoding(song("AUDIO/MPEG", bitrate = 128_000))).isFalse()
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchAudioTranscoderTest.kt
@@ -18,6 +18,7 @@ class WatchAudioTranscoderTest {
     private val transcoder = WatchAudioTranscoder(
         application = mockk<Application>(relaxed = true),
         mainDispatcher = Dispatchers.Unconfined,
+        ioDispatcher = Dispatchers.Unconfined,
     )
 
     private fun song(mimeType: String?, bitrate: Int?) =
@@ -50,12 +51,43 @@ class WatchAudioTranscoderTest {
     }
 
     @Test
-    fun `unknown bitrate requires transcoding even for an otherwise eligible lossy mimeType`() {
+    fun `unknown bitrate requires transcoding when nothing else is known about the song`() {
+        // The Song-based overload only sees what the library scanned. transcodeIfNeeded probes
+        // the file before deciding, so this conservative answer is not what a real unknown-bitrate
+        // MP3 gets — see the resolved-bitrate case below.
         assertThat(transcoder.requiresTranscoding(song("audio/mpeg", bitrate = null))).isTrue()
+    }
+
+    @Test
+    fun `a lossy source whose bitrate was resolved by probing is sent as-is`() {
+        assertThat(transcoder.requiresTranscoding("audio/mpeg", bitrateBps = 192_000)).isFalse()
+        assertThat(transcoder.requiresTranscoding("audio/mpeg", bitrateBps = 320_000)).isTrue()
     }
 
     @Test
     fun `mimeType is matched case-insensitively`() {
         assertThat(transcoder.requiresTranscoding(song("AUDIO/MPEG", bitrate = 128_000))).isFalse()
+    }
+
+    @Test
+    fun `an unprobed lossy source is estimated above the transcode target, not at it`() {
+        // It will most likely pass through untouched at its real bitrate, so sizing it at the
+        // AAC target would systematically undershoot the confirmation sheet's estimate.
+        assertThat(transcoder.estimatedTransferBitrateBps(song("audio/mpeg", bitrate = null)))
+            .isGreaterThan(WatchAudioTranscoder.TARGET_BITRATE_BPS)
+    }
+
+    @Test
+    fun `songs that will be transcoded are estimated at the AAC target bitrate`() {
+        assertThat(transcoder.estimatedTransferBitrateBps(song("audio/flac", bitrate = null)))
+            .isEqualTo(WatchAudioTranscoder.TARGET_BITRATE_BPS)
+        assertThat(transcoder.estimatedTransferBitrateBps(song("audio/mpeg", bitrate = 320_000)))
+            .isEqualTo(WatchAudioTranscoder.TARGET_BITRATE_BPS)
+    }
+
+    @Test
+    fun `a passthrough song with a known bitrate is estimated at that bitrate`() {
+        assertThat(transcoder.estimatedTransferBitrateBps(song("audio/mpeg", bitrate = 192_000)))
+            .isEqualTo(192_000)
     }
 }

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimatorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimatorTest.kt
@@ -12,6 +12,7 @@ class WatchPlaylistTransferEstimatorTest {
     private val transcoder = WatchAudioTranscoder(
         application = mockk<Application>(relaxed = true),
         mainDispatcher = Dispatchers.Unconfined,
+        ioDispatcher = Dispatchers.Unconfined,
     )
 
     private fun song(id: String, mimeType: String?, bitrate: Int?, durationMs: Long = 180_000L) =

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimatorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/wear/WatchPlaylistTransferEstimatorTest.kt
@@ -1,0 +1,84 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import android.app.Application
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.model.Song
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import org.junit.jupiter.api.Test
+
+class WatchPlaylistTransferEstimatorTest {
+
+    private val transcoder = WatchAudioTranscoder(
+        application = mockk<Application>(relaxed = true),
+        mainDispatcher = Dispatchers.Unconfined,
+    )
+
+    private fun song(id: String, mimeType: String?, bitrate: Int?, durationMs: Long = 180_000L) =
+        Song.emptySong().copy(id = id, mimeType = mimeType, bitrate = bitrate, duration = durationMs)
+
+    @Test
+    fun `passthrough song is sized using its own bitrate`() {
+        val passthroughSong = song("s1", "audio/mpeg", bitrate = 128_000, durationMs = 60_000L)
+
+        val bytes = WatchPlaylistTransferEstimator.estimateBytesForSong(passthroughSong, transcoder)
+
+        // 60s * 128_000 bps / 8 = 960_000 bytes
+        assertThat(bytes).isEqualTo(960_000L)
+    }
+
+    @Test
+    fun `transcoded song is sized using the target AAC bitrate, not its source bitrate`() {
+        val losslessSong = song("s1", "audio/flac", bitrate = 900_000, durationMs = 60_000L)
+
+        val bytes = WatchPlaylistTransferEstimator.estimateBytesForSong(losslessSong, transcoder)
+
+        // 60s * 128_000 (TARGET_BITRATE_BPS) bps / 8 = 960_000 bytes, not sized off the 900kbps source.
+        assertThat(bytes).isEqualTo(960_000L)
+    }
+
+    @Test
+    fun `estimate only sums pending songs, not the whole playlist`() {
+        val alreadyOnWatch = song("on-watch", "audio/mpeg", bitrate = 128_000, durationMs = 60_000L)
+        val pending = song("pending", "audio/mpeg", bitrate = 128_000, durationMs = 60_000L)
+
+        val estimate = WatchPlaylistTransferEstimator.estimate(
+            allSongs = listOf(alreadyOnWatch, pending),
+            pendingSongs = listOf(pending),
+            transcoder = transcoder,
+        )
+
+        assertThat(estimate.totalSongCount).isEqualTo(2)
+        assertThat(estimate.pendingSongCount).isEqualTo(1)
+        assertThat(estimate.estimatedBytes).isEqualTo(960_000L)
+    }
+
+    @Test
+    fun `no pending songs means zero bytes and zero seconds`() {
+        val onlySong = song("s1", "audio/mpeg", bitrate = 128_000)
+
+        val estimate = WatchPlaylistTransferEstimator.estimate(
+            allSongs = listOf(onlySong),
+            pendingSongs = emptyList(),
+            transcoder = transcoder,
+        )
+
+        assertThat(estimate.pendingSongCount).isEqualTo(0)
+        assertThat(estimate.estimatedBytes).isEqualTo(0L)
+        assertThat(estimate.estimatedTransferSeconds).isEqualTo(0L)
+    }
+
+    @Test
+    fun `a small pending transfer still estimates at least one second`() {
+        val tinySong = song("s1", "audio/mpeg", bitrate = 128_000, durationMs = 1L)
+
+        val estimate = WatchPlaylistTransferEstimator.estimate(
+            allSongs = listOf(tinySong),
+            pendingSongs = listOf(tinySong),
+            transcoder = transcoder,
+        )
+
+        assertThat(estimate.estimatedBytes).isGreaterThan(0L)
+        assertThat(estimate.estimatedTransferSeconds).isEqualTo(1L)
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModelTest.kt
@@ -1,0 +1,161 @@
+package com.theveloper.pixelplay.presentation.viewmodel
+
+import android.content.Context
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.MainCoroutineExtension
+import com.theveloper.pixelplay.data.DailyMixManager
+import com.theveloper.pixelplay.data.ai.AiPlaylistGenerator
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.playlist.M3uManager
+import com.theveloper.pixelplay.data.preferences.PlaylistPreferencesRepository
+import com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode
+import com.theveloper.pixelplay.data.repository.MusicRepository
+import com.theveloper.pixelplay.data.service.wear.PhoneWatchTransferStateStore
+import com.theveloper.pixelplay.data.service.wear.PlaylistWatchTransferCoordinator
+import com.theveloper.pixelplay.data.service.wear.WatchAudioTranscoder
+import com.theveloper.pixelplay.data.service.wear.WearPhoneTransferSender
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Covers only the watch-transfer surface this feature adds — estimateWatchTransfer,
+ * isPlaylistFullyOnWatch, sendPlaylistToWatch, cancelPlaylistTransfer, activePlaylistBatchTransfer,
+ * refreshWatchAvailability. The rest of PlaylistViewModel's large existing surface (CRUD,
+ * sorting, AI generation, M3U import/export) is out of scope for this change and untouched.
+ */
+@ExperimentalCoroutinesApi
+@ExtendWith(MainCoroutineExtension::class)
+class PlaylistViewModelTest {
+
+    private val playlistPreferencesRepository = mockk<PlaylistPreferencesRepository>()
+    private val musicRepository = mockk<MusicRepository>()
+    private val dailyMixManager = mockk<DailyMixManager>(relaxed = true)
+    private val aiPlaylistGenerator = mockk<AiPlaylistGenerator>(relaxed = true)
+    private val m3uManager = mockk<M3uManager>(relaxed = true)
+    private val playlistWatchTransferCoordinator = mockk<PlaylistWatchTransferCoordinator>()
+    private val watchTransferStateStore = PhoneWatchTransferStateStore()
+    private val wearPhoneTransferSender = mockk<WearPhoneTransferSender>()
+    private val watchAudioTranscoder = mockk<WatchAudioTranscoder>()
+    private val context = mockk<Context>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        every { playlistPreferencesRepository.userPlaylistsFlow } returns flowOf(emptyList())
+        every { playlistPreferencesRepository.playlistSongOrderModesFlow } returns flowOf(emptyMap())
+        every { playlistPreferencesRepository.playlistsSortOptionFlow } returns flowOf("")
+        every { playlistPreferencesRepository.showTelegramCloudPlaylistsFlow } returns flowOf(true)
+        every { playlistPreferencesRepository.telegramTopicDisplayModeFlow } returns
+            flowOf(TelegramTopicDisplayMode.CHANNELS_AND_TOPICS)
+        coEvery { wearPhoneTransferSender.refreshWatchPairingState() } returns true
+    }
+
+    private fun buildViewModel() = PlaylistViewModel(
+        playlistPreferencesRepository = playlistPreferencesRepository,
+        musicRepository = musicRepository,
+        dailyMixManager = dailyMixManager,
+        aiPlaylistGenerator = aiPlaylistGenerator,
+        m3uManager = m3uManager,
+        playlistWatchTransferCoordinator = playlistWatchTransferCoordinator,
+        watchTransferStateStore = watchTransferStateStore,
+        wearPhoneTransferSender = wearPhoneTransferSender,
+        watchAudioTranscoder = watchAudioTranscoder,
+        context = context,
+    )
+
+    private fun song(id: String, mimeType: String = "audio/mpeg", bitrate: Int? = 128_000) =
+        Song.emptySong().copy(id = id, mimeType = mimeType, bitrate = bitrate)
+
+    @Test
+    fun `estimateWatchTransfer only counts songs not already on every reachable watch`() = runTest {
+        coEvery { watchAudioTranscoder.transcodeIfNeeded(any(), any(), any()) } returns
+            WatchAudioTranscoder.TranscodeResult.Passthrough
+        every { watchAudioTranscoder.requiresTranscoding(any()) } returns false
+        watchTransferStateStore.retainReachableWatchNodes(setOf("node-1"))
+        watchTransferStateStore.markSongPresentOnWatch("node-1", "already-there")
+        val viewModel = buildViewModel()
+
+        val estimate = viewModel.estimateWatchTransfer(listOf(song("already-there"), song("pending")))
+
+        assertThat(estimate.totalSongCount).isEqualTo(2)
+        assertThat(estimate.pendingSongCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `isPlaylistFullyOnWatch is false for an empty playlist`() {
+        val viewModel = buildViewModel()
+        assertThat(viewModel.isPlaylistFullyOnWatch(emptyList())).isFalse()
+    }
+
+    @Test
+    fun `isPlaylistFullyOnWatch is true only once every song is on every reachable watch`() {
+        watchTransferStateStore.retainReachableWatchNodes(setOf("node-1"))
+        val viewModel = buildViewModel()
+
+        assertThat(viewModel.isPlaylistFullyOnWatch(listOf("s1", "s2"))).isFalse()
+
+        watchTransferStateStore.markSongPresentOnWatch("node-1", "s1")
+        assertThat(viewModel.isPlaylistFullyOnWatch(listOf("s1", "s2"))).isFalse()
+
+        watchTransferStateStore.markSongPresentOnWatch("node-1", "s2")
+        assertThat(viewModel.isPlaylistFullyOnWatch(listOf("s1", "s2"))).isTrue()
+    }
+
+    @Test
+    fun `sendPlaylistToWatch delegates to the coordinator and returns its batchId`() {
+        every {
+            playlistWatchTransferCoordinator.requestPlaylistTransfer("p1", "Playlist", listOf("s1", "s2"))
+        } returns "batch-123"
+        val viewModel = buildViewModel()
+
+        val batchId = viewModel.sendPlaylistToWatch("p1", "Playlist", listOf("s1", "s2"))
+
+        assertThat(batchId).isEqualTo("batch-123")
+    }
+
+    @Test
+    fun `cancelPlaylistTransfer delegates to the coordinator`() {
+        every { playlistWatchTransferCoordinator.cancelPlaylistTransfer("batch-123") } returns Unit
+        val viewModel = buildViewModel()
+
+        viewModel.cancelPlaylistTransfer("batch-123")
+
+        io.mockk.verify { playlistWatchTransferCoordinator.cancelPlaylistTransfer("batch-123") }
+    }
+
+    @Test
+    fun `activePlaylistBatchTransfer reflects the only non-terminal batch in the shared store`() = runTest {
+        // stateIn(WhileSubscribed) only starts collecting the upstream flow once something
+        // subscribes — reading .value without a collector never triggers it, so this needs an
+        // actual subscriber (Turbine's test{}), not a bare .value read.
+        val viewModel = buildViewModel()
+
+        viewModel.activePlaylistBatchTransfer.test {
+            assertThat(awaitItem()).isNull()
+
+            watchTransferStateStore.markBatchStarted("b1", "p1", "Playlist", totalSongCount = 3)
+
+            assertThat(awaitItem()?.batchId).isEqualTo("b1")
+        }
+    }
+
+    @Test
+    fun `refreshWatchAvailability updates isPixelPlayWatchAvailable from the sender`() = runTest {
+        coEvery { wearPhoneTransferSender.isPixelPlayWatchAvailable() } returns true
+        coEvery { wearPhoneTransferSender.refreshWatchLibraryState() } returns Result.success(Unit)
+        val viewModel = buildViewModel()
+
+        viewModel.refreshWatchAvailability()
+        advanceUntilIdle()
+
+        assertThat(viewModel.isPixelPlayWatchAvailable.value).isTrue()
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModelTest.kt
@@ -78,7 +78,7 @@ class PlaylistViewModelTest {
     fun `estimateWatchTransfer only counts songs not already on every reachable watch`() = runTest {
         coEvery { watchAudioTranscoder.transcodeIfNeeded(any(), any(), any()) } returns
             WatchAudioTranscoder.TranscodeResult.Passthrough
-        every { watchAudioTranscoder.requiresTranscoding(any()) } returns false
+        every { watchAudioTranscoder.estimatedTransferBitrateBps(any()) } returns 128_000
         watchTransferStateStore.retainReachableWatchNodes(setOf("node-1"))
         watchTransferStateStore.markSongPresentOnWatch("node-1", "already-there")
         val viewModel = buildViewModel()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -233,6 +233,7 @@ junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", v
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitJupiter" }
 junit-vintage-engine = { group = "org.junit.vintage", name = "junit-vintage-engine", version.ref = "junitJupiter" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "roomRuntime" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -15,6 +15,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+        unitTests.all { it.useJUnitPlatform() }
+    }
 }
 
 kotlin {
@@ -25,4 +30,16 @@ kotlin {
 
 dependencies {
     implementation(libs.kotlinx.serialization.json)
+
+    // Testing (Unit) — pure DTO serialization round-trips, no Android framework needed.
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junitplatformlauncher)
+    testImplementation(libs.truth)
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearDataPaths.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearDataPaths.kt
@@ -64,4 +64,29 @@ object WearDataPaths {
 
     /** Message path for favorites sync progress/state (phone -> watch) */
     const val FAVORITES_SYNC_STATE = "/favorites_sync_state"
+
+    /** Message path for playlist sync (phone -> watch): creates or updates a local playlist's membership/order. */
+    const val PLAYLIST_SYNC = "/playlist_sync"
+
+    /**
+     * Message path for playlist sync acknowledgement (watch -> phone): confirms a [PLAYLIST_SYNC]
+     * message was actually applied, since `MessageClient.sendMessage()` succeeding on the phone
+     * only means local hand-off, not delivery.
+     */
+    const val PLAYLIST_SYNC_ACK = "/playlist_sync_ack"
+
+    /**
+     * DataItem path for the watch performance toggles configured from the phone's Settings ->
+     * "Reloj" screen (phone -> watch). DataItem, not MessageClient: these need to durably reach
+     * the watch even if it's mid-reconnect when the phone publishes, same reasoning as
+     * [PLAYER_STATE] — see [PLAYLIST_SYNC]'s ack for what happens when a phone->watch send is
+     * only best-effort instead.
+     */
+    const val WEAR_PERFORMANCE_SETTINGS = "/wear_performance_settings"
+
+    /** DataMap keys within [WEAR_PERFORMANCE_SETTINGS]. All three default to `true` on the watch
+     *  if never synced, preserving today's behavior. */
+    const val KEY_SHOW_ALBUM_ART = "show_album_art"
+    const val KEY_DYNAMIC_COLOR_THEMING = "dynamic_color_theming"
+    const val KEY_PLAY_BUTTON_ANIMATION = "play_button_animation"
 }

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearLibraryState.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearLibraryState.kt
@@ -3,9 +3,17 @@ package com.theveloper.pixelplay.shared
 import kotlinx.serialization.Serializable
 
 /**
- * Snapshot of songs currently saved on the watch.
+ * Snapshot of what the watch currently holds, sent in reply to
+ * [WearDataPaths.WATCH_LIBRARY_QUERY].
+ *
+ * [playlistIds] answers a question [songIds] can't: "has this playlist ever been sent to this
+ * watch?". Deriving that from songs alone gets it wrong in both directions — two playlists sharing
+ * a single song would both look already-sent, and it can't tell a playlist that was sent from one
+ * whose songs merely happen to be there. Defaulted so an older watch build, which omits the field,
+ * still parses.
  */
 @Serializable
 data class WearLibraryState(
     val songIds: List<String> = emptyList(),
+    val playlistIds: List<String> = emptyList(),
 )

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearPlaylistSync.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearPlaylistSync.kt
@@ -1,0 +1,33 @@
+package com.theveloper.pixelplay.shared
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Snapshot of a phone playlist sent to the watch so it can be browsed and played offline.
+ *
+ * Sent once when the user taps "send to watch", and again (idempotently) when they tap
+ * "update" — the watch replaces its local membership/order for [playlistId] with [songIds]
+ * on each sync, independent of whether the audio for those songs has already arrived. This
+ * lets the watch show the full playlist and its intended order immediately, while individual
+ * songs keep streaming in afterward.
+ *
+ * [songTitles] is a parallel list to [songIds] (same index = same song) rather than a list of
+ * pairs, so an older watch build ignores it (via `ignoreUnknownKeys`) and an older phone build
+ * omitting it still deserializes cleanly on a newer watch — it's purely cosmetic (lets a song
+ * still awaiting transfer show its real name instead of its raw ID) and never load-bearing for
+ * the transfer itself.
+ *
+ * [requestId] identifies this specific send attempt so the watch's [WearPlaylistSyncAck] can be
+ * correlated back to it — `MessageClient.sendMessage()` doesn't guarantee delivery, so the phone
+ * resends (a new [requestId] each time) until it sees a matching ack. Defaults to "" for the same
+ * backward-compatibility reason as [songTitles]: an old phone build omitting it just means the
+ * watch never acks, and the phone falls back to its old fire-and-forget behavior for that sync.
+ */
+@Serializable
+data class WearPlaylistSync(
+    val playlistId: String,
+    val name: String,
+    val songIds: List<String>,
+    val songTitles: List<String> = emptyList(),
+    val requestId: String = "",
+)

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearPlaylistSyncAck.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearPlaylistSyncAck.kt
@@ -1,0 +1,18 @@
+package com.theveloper.pixelplay.shared
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Sent by the watch back to the phone once a [WearPlaylistSync] has been durably applied to the
+ * local playlist table. `MessageClient.sendMessage()` returning success on the phone only means
+ * the message was handed off locally, not that the watch received it — real hardware testing
+ * showed a sync sent while the watch was mid-reconnect (Wi-Fi/ADB drops intermittently under this
+ * app's own load) is silently lost, leaving the watch with every song's audio but no playlist row
+ * to show them under. The phone waits for this ack (see `PlaylistWatchTransferCoordinator`) and
+ * resends if it doesn't arrive in time.
+ */
+@Serializable
+data class WearPlaylistSyncAck(
+    val playlistId: String,
+    val requestId: String,
+)

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearTransferProgress.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearTransferProgress.kt
@@ -14,12 +14,32 @@ data class WearTransferProgress(
     val totalBytes: Long,
     val status: String,
     val error: String? = null,
+    /** Machine-readable failure reason, so callers can react (retry, prompt for space, ...) without parsing [error]. */
+    val errorCode: String? = null,
 ) {
     companion object {
+        /** Phone is re-encoding the source file before it starts streaming; only meaningful for playlist batches. */
+        const val STATUS_TRANSCODING = "transcoding"
         const val STATUS_TRANSFERRING = "transferring"
         const val STATUS_COMPLETED = "completed"
         const val STATUS_FAILED = "failed"
         const val STATUS_CANCELLED = "cancelled"
+        /**
+         * Sent from the watch to the phone right after it stores the [WearTransferMetadata] for a
+         * request, before the audio channel opens. Lets the phone confirm the metadata actually
+         * arrived instead of racing a blind delay against the audio stream.
+         */
+        const val STATUS_METADATA_RECEIVED = "metadata_received"
+        /**
+         * Phone finished sending the bytes but hasn't yet heard the watch's own write-complete ack.
+         * Local-only to the phone's in-memory/persisted transfer state — never serialized to the watch.
+         */
+        const val STATUS_AWAITING_WATCH_ACK = "awaiting_watch_ack"
+
         const val ERROR_ALREADY_ON_WATCH = "Song is already on watch"
+        const val ERROR_CODE_CONNECTION_LOST = "connection_lost"
+        const val ERROR_CODE_INSUFFICIENT_STORAGE = "insufficient_storage"
+        const val ERROR_CODE_TIMED_OUT = "timed_out"
+        const val ERROR_CODE_GENERIC = "generic"
     }
 }

--- a/shared/src/test/java/com/theveloper/pixelplay/shared/WearPlaylistSyncTest.kt
+++ b/shared/src/test/java/com/theveloper/pixelplay/shared/WearPlaylistSyncTest.kt
@@ -1,0 +1,74 @@
+package com.theveloper.pixelplay.shared
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class WearPlaylistSyncTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `round-trips through JSON preserving song order`() {
+        val original = WearPlaylistSync(
+            playlistId = "playlist-1",
+            name = "Running mix",
+            songIds = listOf("3", "1", "2"),
+        )
+
+        val decoded = json.decodeFromString<WearPlaylistSync>(json.encodeToString(original))
+
+        assertThat(decoded).isEqualTo(original)
+        assertThat(decoded.songIds).containsExactly("3", "1", "2").inOrder()
+    }
+
+    @Test
+    fun `decodes an empty song list`() {
+        val original = WearPlaylistSync(playlistId = "playlist-1", name = "Empty", songIds = emptyList())
+
+        val decoded = json.decodeFromString<WearPlaylistSync>(json.encodeToString(original))
+
+        assertThat(decoded.songIds).isEmpty()
+    }
+
+    @Test
+    fun `ignores unknown fields from a newer sender`() {
+        // The receiving side (watch) may run an older app version than the phone that sent this
+        // payload — unknown fields must not break decoding, only newly-added optional ones should.
+        val payloadWithExtraField =
+            """{"playlistId":"playlist-1","name":"Running mix","songIds":["1"],"futureField":true}"""
+
+        val decoded = json.decodeFromString<WearPlaylistSync>(payloadWithExtraField)
+
+        assertThat(decoded).isEqualTo(
+            WearPlaylistSync(playlistId = "playlist-1", name = "Running mix", songIds = listOf("1")),
+        )
+    }
+
+    @Test
+    fun `round-trips song titles in the same order as song ids`() {
+        val original = WearPlaylistSync(
+            playlistId = "playlist-1",
+            name = "Running mix",
+            songIds = listOf("3", "1", "2"),
+            songTitles = listOf("Third", "First", "Second"),
+        )
+
+        val decoded = json.decodeFromString<WearPlaylistSync>(json.encodeToString(original))
+
+        assertThat(decoded.songTitles).containsExactly("Third", "First", "Second").inOrder()
+    }
+
+    @Test
+    fun `a payload from an older phone without songTitles decodes with an empty list`() {
+        // The mirror case of the unknown-field test above: an OLDER sender that predates this
+        // field entirely, not a newer one adding an extra field this receiver doesn't know yet.
+        val payloadWithoutTitles =
+            """{"playlistId":"playlist-1","name":"Running mix","songIds":["1","2"]}"""
+
+        val decoded = json.decodeFromString<WearPlaylistSync>(payloadWithoutTitles)
+
+        assertThat(decoded.songTitles).isEmpty()
+    }
+}

--- a/shared/src/test/java/com/theveloper/pixelplay/shared/WearTransferProgressTest.kt
+++ b/shared/src/test/java/com/theveloper/pixelplay/shared/WearTransferProgressTest.kt
@@ -1,0 +1,64 @@
+package com.theveloper.pixelplay.shared
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class WearTransferProgressTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `round-trips through JSON with the new errorCode field`() {
+        val original = WearTransferProgress(
+            requestId = "req-1",
+            songId = "song-1",
+            bytesTransferred = 512L,
+            totalBytes = 1024L,
+            status = WearTransferProgress.STATUS_FAILED,
+            error = "Connection lost",
+            errorCode = WearTransferProgress.ERROR_CODE_CONNECTION_LOST,
+        )
+
+        val decoded = json.decodeFromString<WearTransferProgress>(json.encodeToString(original))
+
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `decodes a payload from an older sender that predates errorCode as null`() {
+        // A phone running an older build won't include errorCode in the payload at all.
+        val legacyPayload =
+            """{"requestId":"req-1","songId":"song-1","bytesTransferred":0,"totalBytes":1024,"status":"transferring"}"""
+
+        val decoded = json.decodeFromString<WearTransferProgress>(legacyPayload)
+
+        assertThat(decoded.errorCode).isNull()
+        assertThat(decoded.error).isNull()
+    }
+
+    @Test
+    fun `STATUS_TRANSCODING serializes as its raw string value`() {
+        val progress = WearTransferProgress(
+            requestId = "req-1",
+            songId = "song-1",
+            bytesTransferred = 0L,
+            totalBytes = 1024L,
+            status = WearTransferProgress.STATUS_TRANSCODING,
+        )
+
+        assertThat(json.encodeToString(progress)).contains("\"status\":\"transcoding\"")
+    }
+
+    @Test
+    fun `STATUS_AWAITING_WATCH_ACK is a distinct value from every terminal status`() {
+        val terminalStatuses = setOf(
+            WearTransferProgress.STATUS_COMPLETED,
+            WearTransferProgress.STATUS_FAILED,
+            WearTransferProgress.STATUS_CANCELLED,
+        )
+
+        assertThat(terminalStatuses).doesNotContain(WearTransferProgress.STATUS_AWAITING_WATCH_ACK)
+    }
+}

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -16,6 +16,13 @@ android {
         targetSdk = 37
         versionCode = (project.findProperty("APP_VERSION_CODE") as? String)?.toInt() ?: 1
         versionName = (project.findProperty("APP_VERSION_NAME") as? String) ?: "1.0.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+        unitTests.all { it.useJUnitPlatform() }
     }
 
     buildTypes {
@@ -90,6 +97,10 @@ dependencies {
     // Serialization
     implementation(libs.kotlinx.serialization.json)
 
+    // DataStore (persisting local playback state across process death — see
+    // WearPlaybackStatePersistence)
+    implementation(libs.androidx.datastore.preferences)
+
     // Image loading
     implementation(libs.coil.compose)
 
@@ -117,6 +128,27 @@ dependencies {
     implementation(libs.androidx.media3.session)
     implementation(libs.androidx.mediarouter)
 
+    // Testing (Unit) — no legacy JUnit 4 unit tests planned here, so no vintage engine needed
+    // (compare to :app, which carries pre-existing JUnit 4 tests under useJUnitPlatform()).
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junitplatformlauncher)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
+    testImplementation(libs.truth)
+    testImplementation(kotlin("test"))
+
+    // Testing (Instrumentation) — Room in-memory DAO tests run on-device via AndroidJUnitRunner.
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.room.testing)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
+    androidTestImplementation(libs.truth)
+    // Android-specific artifact: plain io.mockk:mockk can't mock classes on ART.
+    androidTestImplementation(libs.mockk.android)
+
     constraints {
         // Fix vulnerabilities in transitive dependencies
         implementation(libs.netty.common)
@@ -130,4 +162,8 @@ dependencies {
         implementation(libs.jose4j)
         implementation(libs.apache.httpclient)
     }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/wear/src/androidTest/java/com/theveloper/pixelplay/data/local/LocalPlaylistDaoTest.kt
+++ b/wear/src/androidTest/java/com/theveloper/pixelplay/data/local/LocalPlaylistDaoTest.kt
@@ -1,0 +1,130 @@
+package com.theveloper.pixelplay.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class LocalPlaylistDaoTest {
+
+    private lateinit var dao: LocalPlaylistDao
+    private lateinit var db: WearMusicDatabase
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, WearMusicDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.localPlaylistDao()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun upsertPlaylist_isVisibleViaObservePlaylists() = runTest {
+        val playlist = LocalPlaylistEntity(playlistId = "p1", name = "Running mix", createdAt = 1L, updatedAt = 1L)
+        val songs = listOf(
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s1", position = 0),
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s2", position = 1),
+        )
+
+        dao.upsertPlaylist(playlist, songs)
+
+        val stored = dao.observePlaylists().first()
+        assertThat(stored).containsExactly(playlist)
+    }
+
+    @Test
+    fun observePlaylistSongs_isOrderedByPosition() = runTest {
+        val playlist = LocalPlaylistEntity(playlistId = "p1", name = "Running mix", createdAt = 1L, updatedAt = 1L)
+        // Inserted out of order on purpose — the DAO's ORDER BY position must correct this, not
+        // the insertion order.
+        val songs = listOf(
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "third", position = 2),
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "first", position = 0),
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "second", position = 1),
+        )
+
+        dao.upsertPlaylist(playlist, songs)
+
+        val ordered = dao.observePlaylistSongs("p1").first().map { it.songId }
+        assertThat(ordered).containsExactly("first", "second", "third").inOrder()
+    }
+
+    @Test
+    fun upsertPlaylist_replacesPreviousCrossRefsInsteadOfMerging() = runTest {
+        val playlist = LocalPlaylistEntity(playlistId = "p1", name = "Running mix", createdAt = 1L, updatedAt = 1L)
+        dao.upsertPlaylist(
+            playlist,
+            listOf(
+                LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s1", position = 0),
+                LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s2", position = 1),
+            ),
+        )
+
+        // Re-sync with a song removed and the remaining one's position shifted — simulates the
+        // phone re-sending after the user edited the playlist.
+        dao.upsertPlaylist(
+            playlist.copy(updatedAt = 2L),
+            listOf(LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s2", position = 0)),
+        )
+
+        val songIds = dao.observePlaylistSongs("p1").first().map { it.songId }
+        assertThat(songIds).containsExactly("s2")
+    }
+
+    @Test
+    fun upsertPlaylist_doesNotAffectOtherPlaylists() = runTest {
+        dao.upsertPlaylist(
+            LocalPlaylistEntity(playlistId = "p1", name = "Running mix", createdAt = 1L, updatedAt = 1L),
+            listOf(LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s1", position = 0)),
+        )
+        dao.upsertPlaylist(
+            LocalPlaylistEntity(playlistId = "p2", name = "Chill mix", createdAt = 1L, updatedAt = 1L),
+            listOf(LocalPlaylistSongCrossRef(playlistId = "p2", songId = "s2", position = 0)),
+        )
+
+        // Re-sync p1 only.
+        dao.upsertPlaylist(
+            LocalPlaylistEntity(playlistId = "p1", name = "Running mix", createdAt = 1L, updatedAt = 2L),
+            listOf(LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s1-updated", position = 0)),
+        )
+
+        val p2Songs = dao.observePlaylistSongs("p2").first().map { it.songId }
+        assertThat(p2Songs).containsExactly("s2")
+    }
+
+    @Test
+    fun observeAllPlaylistSongCrossRefs_spansEveryPlaylist() = runTest {
+        dao.upsertPlaylist(
+            LocalPlaylistEntity(playlistId = "p1", name = "Running mix", createdAt = 1L, updatedAt = 1L),
+            listOf(LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s1", position = 0)),
+        )
+        dao.upsertPlaylist(
+            LocalPlaylistEntity(playlistId = "p2", name = "Chill mix", createdAt = 1L, updatedAt = 1L),
+            listOf(LocalPlaylistSongCrossRef(playlistId = "p2", songId = "s2", position = 0)),
+        )
+
+        val allSongIds = dao.observeAllPlaylistSongCrossRefs().first().map { it.songId }
+        assertThat(allSongIds).containsExactly("s1", "s2")
+    }
+
+    @Test
+    fun getPlaylistById_returnsNullForAnUnknownPlaylist() = runTest {
+        assertThat(dao.getPlaylistById("missing")).isNull()
+    }
+}

--- a/wear/src/androidTest/java/com/theveloper/pixelplay/data/local/WearMusicDatabaseMigrationTest.kt
+++ b/wear/src/androidTest/java/com/theveloper/pixelplay/data/local/WearMusicDatabaseMigrationTest.kt
@@ -1,0 +1,177 @@
+package com.theveloper.pixelplay.data.local
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies [WearMusicDatabase.MIGRATION_5_6] and [WearMusicDatabase.MIGRATION_6_7] against
+ * hand-built database files.
+ *
+ * `:wear` doesn't export Room schema JSON (`exportSchema = false`), so [androidx.room.testing.MigrationTestHelper]
+ * — which needs those fixtures — isn't available here. Instead this builds a real on-disk SQLite
+ * file matching the source version's shape, then opens it through Room with the migration(s)
+ * attached, the same way a real upgrading device would.
+ */
+@RunWith(AndroidJUnit4::class)
+class WearMusicDatabaseMigrationTest {
+
+    private val dbName = "migration-test-wear-music.db"
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @After
+    fun cleanup() {
+        context.deleteDatabase(dbName)
+    }
+
+    @Test
+    fun migrate5To6_createsPlaylistTablesAndPreservesExistingSongs() = runTest {
+        seedVersion5Database()
+
+        val migratedDb = Room.databaseBuilder(context, WearMusicDatabase::class.java, dbName)
+            .addMigrations(WearMusicDatabase.MIGRATION_5_6, WearMusicDatabase.MIGRATION_6_7)
+            .build()
+
+        try {
+            val song = migratedDb.localSongDao().getSongById("song-1")
+            assertThat(song).isNotNull()
+            assertThat(song?.title).isEqualTo("Existing song")
+
+            // The playlist tables must exist and be queryable — this throws if the migration
+            // didn't run (or ran with malformed SQL) rather than returning a false "empty" result.
+            val playlists = migratedDb.openHelper.readableDatabase.query("SELECT * FROM local_playlists")
+            playlists.use { assertThat(it.count).isEqualTo(0) }
+
+            val playlistSongs = migratedDb.openHelper.readableDatabase.query("SELECT * FROM local_playlist_songs")
+            playlistSongs.use { assertThat(it.count).isEqualTo(0) }
+        } finally {
+            migratedDb.close()
+        }
+    }
+
+    @Test
+    fun migrate6To7_addsPendingTitleColumnDefaultingToEmpty() = runTest {
+        seedVersion6DatabaseWithPlaylistSong()
+
+        val migratedDb = Room.databaseBuilder(context, WearMusicDatabase::class.java, dbName)
+            .addMigrations(WearMusicDatabase.MIGRATION_6_7)
+            .build()
+
+        try {
+            // A row written before this migration existed has no pendingTitle — the migration's
+            // DEFAULT '' must apply, not a NULL that Room's non-null String column would choke on.
+            val crossRef = migratedDb.localPlaylistDao().observePlaylistSongs("p1").first().single()
+            assertThat(crossRef.songId).isEqualTo("s1")
+            assertThat(crossRef.pendingTitle).isEmpty()
+        } finally {
+            migratedDb.close()
+        }
+    }
+
+    /** Hand-writes a v5 database file: the `local_songs` shape frozen right before this migration. */
+    private fun seedVersion5Database() {
+        context.deleteDatabase(dbName)
+        val dbFile = context.getDatabasePath(dbName)
+        dbFile.parentFile?.mkdirs()
+
+        val db = SQLiteDatabase.openOrCreateDatabase(dbFile, null)
+        db.execSQL(
+            "CREATE TABLE local_songs (" +
+                "songId TEXT NOT NULL PRIMARY KEY, " +
+                "title TEXT NOT NULL, " +
+                "artist TEXT NOT NULL, " +
+                "album TEXT NOT NULL, " +
+                "albumId INTEGER NOT NULL, " +
+                "duration INTEGER NOT NULL, " +
+                "mimeType TEXT NOT NULL, " +
+                "fileSize INTEGER NOT NULL, " +
+                "bitrate INTEGER NOT NULL, " +
+                "sampleRate INTEGER NOT NULL, " +
+                "isFavorite INTEGER NOT NULL, " +
+                "favoriteSyncPending INTEGER NOT NULL, " +
+                "paletteSeedArgb INTEGER, " +
+                "themePaletteJson TEXT, " +
+                "artworkPath TEXT, " +
+                "localPath TEXT NOT NULL, " +
+                "transferredAt INTEGER NOT NULL)"
+        )
+        db.execSQL(
+            "INSERT INTO local_songs (songId, title, artist, album, albumId, duration, mimeType, " +
+                "fileSize, bitrate, sampleRate, isFavorite, favoriteSyncPending, paletteSeedArgb, " +
+                "themePaletteJson, artworkPath, localPath, transferredAt) VALUES " +
+                "('song-1', 'Existing song', 'Artist', 'Album', 1, 180000, 'audio/mp4', 4000000, " +
+                "128000, 44100, 0, 0, NULL, NULL, NULL, '/music/song-1.m4a', 1000)"
+        )
+        db.version = 5
+        db.close()
+    }
+
+    /** Hand-writes a v6 database file with one playlist and one cross-ref row, the shape frozen
+     *  right before [WearMusicDatabase.MIGRATION_6_7] added `pendingTitle`. */
+    private fun seedVersion6DatabaseWithPlaylistSong() {
+        context.deleteDatabase(dbName)
+        val dbFile = context.getDatabasePath(dbName)
+        dbFile.parentFile?.mkdirs()
+
+        val db = SQLiteDatabase.openOrCreateDatabase(dbFile, null)
+        db.execSQL(
+            "CREATE TABLE local_songs (" +
+                "songId TEXT NOT NULL PRIMARY KEY, " +
+                "title TEXT NOT NULL, " +
+                "artist TEXT NOT NULL, " +
+                "album TEXT NOT NULL, " +
+                "albumId INTEGER NOT NULL, " +
+                "duration INTEGER NOT NULL, " +
+                "mimeType TEXT NOT NULL, " +
+                "fileSize INTEGER NOT NULL, " +
+                "bitrate INTEGER NOT NULL, " +
+                "sampleRate INTEGER NOT NULL, " +
+                "isFavorite INTEGER NOT NULL, " +
+                "favoriteSyncPending INTEGER NOT NULL, " +
+                "paletteSeedArgb INTEGER, " +
+                "themePaletteJson TEXT, " +
+                "artworkPath TEXT, " +
+                "localPath TEXT NOT NULL, " +
+                "transferredAt INTEGER NOT NULL)"
+        )
+        db.execSQL(
+            "CREATE TABLE local_playlists (" +
+                "playlistId TEXT NOT NULL PRIMARY KEY, " +
+                "name TEXT NOT NULL, " +
+                "createdAt INTEGER NOT NULL, " +
+                "updatedAt INTEGER NOT NULL)"
+        )
+        db.execSQL(
+            "CREATE TABLE local_playlist_songs (" +
+                "playlistId TEXT NOT NULL, " +
+                "songId TEXT NOT NULL, " +
+                "position INTEGER NOT NULL, " +
+                "PRIMARY KEY(playlistId, songId))"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS index_local_playlist_songs_playlistId_position " +
+                "ON local_playlist_songs(playlistId, position)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS index_local_playlist_songs_songId " +
+                "ON local_playlist_songs(songId)"
+        )
+        db.execSQL(
+            "INSERT INTO local_playlists (playlistId, name, createdAt, updatedAt) VALUES " +
+                "('p1', 'Road trip', 1000, 1000)"
+        )
+        db.execSQL(
+            "INSERT INTO local_playlist_songs (playlistId, songId, position) VALUES ('p1', 's1', 0)"
+        )
+        db.version = 6
+        db.close()
+    }
+}

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -77,6 +77,10 @@
                     android:scheme="wear"
                     android:host="*"
                     android:pathPrefix="/player_state" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/wear_performance_settings" />
             </intent-filter>
             <intent-filter>
                 <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
@@ -112,6 +116,10 @@
                     android:scheme="wear"
                     android:host="*"
                     android:pathPrefix="/volume_state" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/playlist_sync" />
             </intent-filter>
             <intent-filter>
                 <action android:name="com.google.android.gms.wearable.CHANNEL_EVENT" />

--- a/wear/src/main/java/com/theveloper/pixelplay/WearApp.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/WearApp.kt
@@ -1,15 +1,44 @@
 package com.theveloper.pixelplay
 
 import android.app.Application
+import com.theveloper.pixelplay.data.WearPerformanceSettingsRepository
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import timber.log.Timber
+import javax.inject.Inject
 
 @HiltAndroidApp
 class WearApp : Application() {
+
+    @Inject
+    lateinit var performanceSettingsRepository: dagger.Lazy<WearPerformanceSettingsRepository>
+
+    private val startupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
+        }
+
+        startupScope.launch {
+            // The performance toggles otherwise only ever arrive as a push, which a fresh install
+            // of this app can never receive: reinstalling wipes the local copy back to the
+            // all-enabled defaults, and the phone re-announcing the same values produces a
+            // byte-identical DataItem that the Data Layer drops as unchanged. Pulling the
+            // published item once per process start is what makes the toggles actually stick.
+            // Best-effort: a failure here just leaves this session on the previous values.
+            try {
+                performanceSettingsRepository.get().refreshFromPhone()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to refresh watch performance settings at startup")
+            }
         }
     }
 }

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearAudioOffloadPolicy.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearAudioOffloadPolicy.kt
@@ -1,0 +1,34 @@
+package com.theveloper.pixelplay.data
+
+/**
+ * Decides whether a stall shortly after audio-offload playback started should be read as an
+ * offload HAL reset and trigger falling back to normal (non-offload) playback for the rest of
+ * the session.
+ *
+ * Mirrors the phone's `DualPlayerEngine.shouldDisableAudioOffloadOnEarlyBuffering` — same
+ * pattern, simplified for [WearPlaybackService]'s single-player service (the phone's version
+ * also guards against its dual-player crossfade transitions, which don't exist here). Wear OS
+ * has no equivalent yet to the phone's per-OEM offload denylist
+ * (`shouldDisableAudioOffloadByDefaultForDevice` in `:app`) — there is no field evidence of which
+ * watch chipsets misbehave with offload, so [WearPlaybackService] always requests it and relies
+ * entirely on this runtime safety net instead of guessing at a denylist with no evidence behind
+ * it.
+ *
+ * The buffering is NOT treated as a HAL reset when it's explained by a recent user seek
+ * ([isPostSeekBuffering]) or a track change ([isPostMediaItemTransition]) — in those cases
+ * buffering is expected, and falling back would needlessly rebuild the player (an audible
+ * glitch) for no reason.
+ */
+internal fun wearShouldFallBackFromAudioOffload(
+    audioOffloadEnabled: Boolean,
+    lastPlayingAtMs: Long,
+    timeSincePlayingMs: Long,
+    isPostSeekBuffering: Boolean,
+    isPostMediaItemTransition: Boolean,
+): Boolean {
+    return audioOffloadEnabled &&
+        lastPlayingAtMs > 0L &&
+        timeSincePlayingMs < 500L &&
+        !isPostSeekBuffering &&
+        !isPostMediaItemTransition
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearDataListenerService.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearDataListenerService.kt
@@ -17,11 +17,13 @@ import com.theveloper.pixelplay.shared.WearDataPaths
 import com.theveloper.pixelplay.shared.WearFavoriteSyncResponse
 import com.theveloper.pixelplay.shared.WearPlaybackResult
 import com.theveloper.pixelplay.shared.WearPlayerState
+import com.theveloper.pixelplay.shared.WearPlaylistSync
 import com.theveloper.pixelplay.shared.WearTransferMetadata
 import com.theveloper.pixelplay.shared.WearTransferProgress
 import com.theveloper.pixelplay.shared.WearTransferRequest
 import com.theveloper.pixelplay.shared.WearVolumeState
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -57,6 +59,9 @@ class WearDataListenerService : WearableListenerService() {
     @Inject
     lateinit var favoriteSyncRepository: WearFavoriteSyncRepository
 
+    @Inject
+    lateinit var performanceSettingsRepository: WearPerformanceSettingsRepository
+
     private val json = Json { ignoreUnknownKeys = true }
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -83,14 +88,32 @@ class WearDataListenerService : WearableListenerService() {
 
             val dataItem = event.dataItem
             Timber.tag(TAG).d("Data event path=%s", dataItem.uri.path)
-            if (dataItem.uri.path == WearDataPaths.PLAYER_STATE) {
-                // Copy DataMap in callback thread; DataEventBuffer is invalid once callback returns.
-                val dataMap = DataMapItem.fromDataItem(dataItem).dataMap
-                scope.launch {
-                    try {
-                        processPlayerStateUpdate(dataMap)
-                    } catch (e: Exception) {
-                        Timber.tag(TAG).e(e, "Failed to process player state update")
+            when (dataItem.uri.path) {
+                WearDataPaths.PLAYER_STATE -> {
+                    // Copy DataMap in callback thread; DataEventBuffer is invalid once callback returns.
+                    val dataMap = DataMapItem.fromDataItem(dataItem).dataMap
+                    scope.launch {
+                        try {
+                            processPlayerStateUpdate(dataMap)
+                        } catch (e: Exception) {
+                            Timber.tag(TAG).e(e, "Failed to process player state update")
+                        }
+                    }
+                }
+
+                WearDataPaths.WEAR_PERFORMANCE_SETTINGS -> {
+                    val dataMap = DataMapItem.fromDataItem(dataItem).dataMap
+                    scope.launch {
+                        try {
+                            performanceSettingsRepository.save(
+                                showAlbumArt = dataMap.getBoolean(WearDataPaths.KEY_SHOW_ALBUM_ART, true),
+                                dynamicColorTheming = dataMap.getBoolean(WearDataPaths.KEY_DYNAMIC_COLOR_THEMING, true),
+                                playButtonAnimation = dataMap.getBoolean(WearDataPaths.KEY_PLAY_BUTTON_ANIMATION, true),
+                            )
+                            Timber.tag(TAG).d("Performance settings synced from phone")
+                        } catch (e: Exception) {
+                            Timber.tag(TAG).e(e, "Failed to process performance settings sync")
+                        }
                     }
                 }
             }
@@ -248,6 +271,20 @@ class WearDataListenerService : WearableListenerService() {
                         )
                     } catch (e: Exception) {
                         Timber.tag(TAG).e(e, "Failed to process transfer metadata")
+                    }
+                }
+            }
+
+            WearDataPaths.PLAYLIST_SYNC -> {
+                scope.launch {
+                    try {
+                        val syncJson = String(messageEvent.data, Charsets.UTF_8)
+                        val sync = json.decodeFromString<WearPlaylistSync>(syncJson)
+                        transferRepository.onPlaylistSyncReceived(sync, sourceNodeId = messageEvent.sourceNodeId)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Timber.tag(TAG).e(e, "Failed to process playlist sync")
                     }
                 }
             }

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearDataListenerService.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearDataListenerService.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import kotlinx.serialization.json.Json
 import timber.log.Timber
@@ -103,7 +104,14 @@ class WearDataListenerService : WearableListenerService() {
 
                 WearDataPaths.WEAR_PERFORMANCE_SETTINGS -> {
                     val dataMap = DataMapItem.fromDataItem(dataItem).dataMap
-                    scope.launch {
+                    // Written inline rather than through `scope`: onDataChanged already runs on
+                    // the Data Layer's own background thread, and this service is torn down as
+                    // soon as its callbacks return — onDestroy cancels `scope`, so a launched
+                    // DataStore write races that teardown and can be dropped before it lands.
+                    // Player state can absorb a dropped update (it streams continuously); this
+                    // is a one-shot event, and losing it leaves the toggles stuck at their
+                    // defaults with no way for the watch to notice.
+                    runBlocking {
                         try {
                             performanceSettingsRepository.save(
                                 showAlbumArt = dataMap.getBoolean(WearDataPaths.KEY_SHOW_ALBUM_ART, true),

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearLoadControlProfile.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearLoadControlProfile.kt
@@ -1,0 +1,41 @@
+package com.theveloper.pixelplay.data
+
+/** ExoPlayer [androidx.media3.exoplayer.DefaultLoadControl] buffer durations (ms). */
+internal data class WearLoadControlBufferProfile(
+    val minBufferMs: Int,
+    val maxBufferMs: Int,
+    val bufferForPlaybackMs: Int,
+    val bufferForPlaybackAfterRebufferMs: Int,
+)
+
+/**
+ * Picks the [androidx.media3.exoplayer.DefaultLoadControl] buffer profile for
+ * [WearPlaybackService]'s player.
+ *
+ * Mirrors the phone's `DualPlayerEngine.buildAdaptiveLoadControl()` RAM tiering — the same
+ * reasoning applies here, amplified: a Wear OS SoC has far less RAM and CPU headroom than even
+ * a low-end phone, and it's sharing both with whatever fitness/health app the user has running
+ * at the same time (confirmed on-device: the app's own process was recycled during a system-wide
+ * low-memory episode while a workout tracker ran alongside local playback). ExoPlayer's default
+ * buffer window wasn't sized for that, and measured on-device it produced sustained
+ * PLAYING/BUFFERING oscillation. [android.app.ActivityManager.isLowRamDevice] is the same signal
+ * the phone already uses to pick its conservative tier, so this reuses it rather than inventing a
+ * new watch-specific threshold with no evidence behind it.
+ */
+internal fun wearLoadControlBufferProfileFor(isLowRamDevice: Boolean): WearLoadControlBufferProfile {
+    return if (isLowRamDevice) {
+        WearLoadControlBufferProfile(
+            minBufferMs = 15_000,
+            maxBufferMs = 30_000,
+            bufferForPlaybackMs = 2_500,
+            bufferForPlaybackAfterRebufferMs = 5_000,
+        )
+    } else {
+        WearLoadControlBufferProfile(
+            minBufferMs = 30_000,
+            maxBufferMs = 60_000,
+            bufferForPlaybackMs = 2_500,
+            bufferForPlaybackAfterRebufferMs = 5_000,
+        )
+    }
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
@@ -154,6 +154,18 @@ class WearLocalPlayerRepository @Inject constructor(
                 updatePaletteForSong(_localPlayerState.value.songId)
             }
         }
+        // Both gates below refuse to do anything until the toggles are known, so this is what
+        // actually loads the art/palette on a normal start — the toggle flows themselves often
+        // never change value, and their collectors above would then never fire.
+        // Deliberately no drop(1) here, unlike the two above: this repository may well be
+        // constructed after the toggles already resolved, and dropping that first emission would
+        // mean the art/palette never load at all for the rest of the session.
+        scope.launch {
+            performanceSettings.isResolved.collect {
+                updatePaletteForSong(_localPlayerState.value.songId)
+                updateArtworkForSong(_localPlayerState.value.songId)
+            }
+        }
     }
 
     private val playerListener = object : Player.Listener {
@@ -750,7 +762,13 @@ class WearLocalPlayerRepository @Inject constructor(
     }
 
     private fun updatePaletteForSong(songId: String) {
-        if (songId.isBlank() || !performanceSettings.dynamicColorTheming.value) {
+        // !isResolved is treated exactly like "the toggle is off": the settings may still be
+        // about to arrive, and deriving a palette now only to drop it a second later is the
+        // visible flicker this guard exists to prevent.
+        if (songId.isBlank() ||
+            !performanceSettings.isResolved.value ||
+            !performanceSettings.dynamicColorTheming.value
+        ) {
             // Also reset lastPaletteSongId when the toggle is off (not just for a blank songId):
             // otherwise re-enabling it later without a song change would leave it pointing at a
             // song that's technically "already handled" and skip re-extracting the seed.
@@ -816,7 +834,11 @@ class WearLocalPlayerRepository @Inject constructor(
     }
 
     private fun updateArtworkForSong(songId: String) {
-        if (songId.isBlank() || !performanceSettings.showAlbumArt.value) {
+        // Same "not resolved yet counts as off" rule as updatePaletteForSong.
+        if (songId.isBlank() ||
+            !performanceSettings.isResolved.value ||
+            !performanceSettings.showAlbumArt.value
+        ) {
             // Same reasoning as updatePaletteForSong: reset lastArtworkSongId even when the
             // toggle (not a blank songId) is why we're bailing, so a later re-enable without a
             // song change still triggers a fresh decode instead of being silently skipped.

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -81,6 +82,8 @@ data class WearQueueSong(
 class WearLocalPlayerRepository @Inject constructor(
     private val application: Application,
     private val localSongDao: LocalSongDao,
+    private val playbackStatePersistence: WearPlaybackStatePersistence,
+    private val performanceSettings: WearPerformanceSettingsRepository,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val json = Json { ignoreUnknownKeys = true }
@@ -116,6 +119,7 @@ class WearLocalPlayerRepository @Inject constructor(
     companion object {
         private const val TAG = "WearLocalPlayer"
         private const val POSITION_UPDATE_INTERVAL_MS = 1000L
+        private const val PERSIST_INTERVAL_TICKS = 10
     }
 
     init {
@@ -135,6 +139,21 @@ class WearLocalPlayerRepository @Inject constructor(
                 }
             }
         }
+
+        // React to the performance toggles changing while a song is already loaded — e.g. the
+        // user turns "show album art" off from the phone mid-song: drop the bitmap immediately
+        // instead of waiting for the next song change, since the whole point is freeing RAM right
+        // away. drop(1) skips the initial replay so this doesn't fire redundantly at construction.
+        scope.launch {
+            performanceSettings.showAlbumArt.drop(1).collect {
+                updateArtworkForSong(_localPlayerState.value.songId)
+            }
+        }
+        scope.launch {
+            performanceSettings.dynamicColorTheming.drop(1).collect {
+                updatePaletteForSong(_localPlayerState.value.songId)
+            }
+        }
     }
 
     private val playerListener = object : Player.Listener {
@@ -142,16 +161,21 @@ class WearLocalPlayerRepository @Inject constructor(
             updateState()
             if (playbackState == Player.STATE_ENDED) {
                 stopPositionUpdates()
+                // Nothing left to resume — clear rather than leave a stale "restore" prompt
+                // pointing at a queue that already finished.
+                clearPersistedPlaybackState()
             }
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             updateState()
+            persistCurrentPlaybackState()
             if (isPlaying) startPositionUpdates() else stopPositionUpdates()
         }
 
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
             updateState()
+            persistCurrentPlaybackState()
         }
     }
 
@@ -472,6 +496,7 @@ class WearLocalPlayerRepository @Inject constructor(
      */
     fun release() {
         stopPositionUpdates()
+        clearPersistedPlaybackState()
         mediaController?.let { controller ->
             controller.removeListener(playerListener)
             runCatching {
@@ -536,6 +561,7 @@ class WearLocalPlayerRepository @Inject constructor(
     private fun startPositionUpdates() {
         positionUpdateJob?.cancel()
         positionUpdateJob = scope.launch {
+            var ticksSinceLastPersist = 0
             while (isActive) {
                 // Skip the StateFlow churn when the user can't see the UI: the
                 // ExoPlayer keeps tracking position internally, we just don't
@@ -545,9 +571,85 @@ class WearLocalPlayerRepository @Inject constructor(
                 if (WearLifecycleState.isInteractiveNow) {
                     updateState()
                 }
+                // Coarser than the 1s UI tick: a DataStore write every second would be real,
+                // pointless disk I/O on a device this battery-constrained. Losing up to
+                // PERSIST_INTERVAL_TICKS seconds of position on a crash is an acceptable
+                // trade — onIsPlayingChanged/onMediaItemTransition already persist immediately
+                // on the events that matter most (a pause or a track change right before a
+                // crash won't be lost).
+                ticksSinceLastPersist++
+                if (ticksSinceLastPersist >= PERSIST_INTERVAL_TICKS) {
+                    ticksSinceLastPersist = 0
+                    persistCurrentPlaybackState()
+                }
                 delay(POSITION_UPDATE_INTERVAL_MS)
             }
         }
+    }
+
+    private fun persistCurrentPlaybackState() {
+        val player = mediaController ?: return
+        if (currentQueueSongIds.isEmpty()) return
+        val snapshot = PersistedLocalPlaybackState(
+            queueSongIds = currentQueueSongIds,
+            currentIndex = player.currentMediaItemIndex,
+            positionMs = player.currentPosition,
+            updatedAtMillis = System.currentTimeMillis(),
+        )
+        scope.launch {
+            runCatching { playbackStatePersistence.save(snapshot) }
+                .onFailure { error -> Timber.tag(TAG).w(error, "Failed to persist local playback state") }
+        }
+    }
+
+    private fun clearPersistedPlaybackState() {
+        scope.launch {
+            runCatching { playbackStatePersistence.clear() }
+                .onFailure { error -> Timber.tag(TAG).w(error, "Failed to clear persisted local playback state") }
+        }
+    }
+
+    /**
+     * Restores a persisted queue, paused, if one exists and is still fresh enough
+     * ([isPersistedLocalPlaybackStateRestorable]) — the recovery path for a process that died
+     * mid-playback (see this class's KDoc). Paused rather than auto-playing: starting audio
+     * without a fresh user gesture on app open would be surprising, especially for headphones
+     * that may no longer even be in the user's ears.
+     *
+     * Safe to call unconditionally on startup: a no-op if nothing is local-playback-active
+     * to restore, and it never overwrites an already-active queue.
+     */
+    suspend fun restorePersistedPlaybackIfAvailable(): Boolean {
+        if (_isLocalPlaybackActive.value) return false
+        val persisted = playbackStatePersistence.read() ?: return false
+        if (!isPersistedLocalPlaybackStateRestorable(persisted, System.currentTimeMillis())) {
+            playbackStatePersistence.clear()
+            return false
+        }
+
+        val songsById = persisted.queueSongIds
+            .mapNotNull { songId -> localSongDao.getSongById(songId) }
+            .associateBy { it.songId }
+        // Songs may have been deleted from the watch since the snapshot was taken (storage
+        // pressure, the user removing a download) — only resume the ones that are still there,
+        // in their original relative order.
+        val playableSongs = persisted.queueSongIds.mapNotNull { songsById[it] }
+        if (playableSongs.isEmpty()) {
+            playbackStatePersistence.clear()
+            return false
+        }
+
+        val originalIndexSongId = persisted.queueSongIds.getOrNull(persisted.currentIndex)
+        val restoredIndex = playableSongs.indexOfFirst { it.songId == originalIndexSongId }
+            .let { if (it >= 0) it else 0 }
+
+        playLocalSongs(
+            songs = playableSongs,
+            startIndex = restoredIndex,
+            startPositionMs = persisted.positionMs,
+            autoPlay = false,
+        )
+        return true
     }
 
     private fun stopPositionUpdates() {
@@ -644,7 +746,10 @@ class WearLocalPlayerRepository @Inject constructor(
     }
 
     private fun updatePaletteForSong(songId: String) {
-        if (songId.isBlank()) {
+        if (songId.isBlank() || !performanceSettings.dynamicColorTheming.value) {
+            // Also reset lastPaletteSongId when the toggle is off (not just for a blank songId):
+            // otherwise re-enabling it later without a song change would leave it pointing at a
+            // song that's technically "already handled" and skip re-extracting the seed.
             lastPaletteSongId = ""
             _localThemePalette.value = null
             _localPaletteSeedArgb.value = null
@@ -707,7 +812,10 @@ class WearLocalPlayerRepository @Inject constructor(
     }
 
     private fun updateArtworkForSong(songId: String) {
-        if (songId.isBlank()) {
+        if (songId.isBlank() || !performanceSettings.showAlbumArt.value) {
+            // Same reasoning as updatePaletteForSong: reset lastArtworkSongId even when the
+            // toggle (not a blank songId) is why we're bailing, so a later re-enable without a
+            // song change still triggers a fresh decode instead of being silently skipped.
             lastArtworkSongId = ""
             _localAlbumArt.value = null
             return

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
@@ -640,13 +640,17 @@ class WearLocalPlayerRepository @Inject constructor(
         }
 
         val originalIndexSongId = persisted.queueSongIds.getOrNull(persisted.currentIndex)
-        val restoredIndex = playableSongs.indexOfFirst { it.songId == originalIndexSongId }
-            .let { if (it >= 0) it else 0 }
+        val originalIndexInPlayable = playableSongs.indexOfFirst { it.songId == originalIndexSongId }
+        val restoredIndex = originalIndexInPlayable.coerceAtLeast(0)
 
         playLocalSongs(
             songs = playableSongs,
             startIndex = restoredIndex,
-            startPositionMs = persisted.positionMs,
+            // The saved position belongs to the song that was playing, so it only travels with
+            // it: when that song is one of the deleted ones we fall back to the first remaining
+            // track, and seeking that to the old position would resume a different song
+            // mid-way — or past its end entirely, which just ends playback immediately.
+            startPositionMs = if (originalIndexInPlayable >= 0) persisted.positionMs else 0L,
             autoPlay = false,
         )
         return true

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepository.kt
@@ -1,9 +1,14 @@
 package com.theveloper.pixelplay.data
 
+import android.net.Uri
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.PutDataRequest
+import com.theveloper.pixelplay.shared.WearDataPaths
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -11,6 +16,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.tasks.await
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,6 +38,7 @@ import javax.inject.Singleton
 @Singleton
 class WearPerformanceSettingsRepository @Inject constructor(
     private val dataStore: DataStore<Preferences>,
+    private val dataClient: DataClient,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -46,12 +54,61 @@ class WearPerformanceSettingsRepository @Inject constructor(
         .map { it[Keys.PLAY_BUTTON_ANIMATION] ?: true }
         .stateIn(scope, SharingStarted.Eagerly, true)
 
+    /**
+     * Reads the phone's current settings DataItem directly and applies it, instead of waiting for
+     * a push into [WearDataListenerService].
+     *
+     * Load-bearing, not a nicety. `onDataChanged` only fires when a DataItem's *content* changes,
+     * and the phone re-announcing the same values is byte-identical, so the Data Layer drops it
+     * silently. A watch whose local copy is out of sync therefore has no way back on its own —
+     * and reinstalling the watch app (every debug build!) wipes this DataStore back to the
+     * all-`true` defaults, which is exactly that state: the phone still shows the toggles off,
+     * the watch behaves as if they were on, and nothing short of the user toggling something on
+     * the phone would ever reconcile them.
+     *
+     * Reading the DataItem is a local Play Services call — the DataItem is already mirrored on
+     * the watch — so this works with the phone out of range, and does nothing at all if the user
+     * has never opened the phone's watch settings (no DataItem, defaults stand).
+     */
+    suspend fun refreshFromPhone() {
+        // Wildcard host to match the item whichever node published it, and FILTER_PREFIX rather
+        // than an exact literal match so the lookup can't miss over a trailing-path detail.
+        val uri = Uri.Builder()
+            .scheme(PutDataRequest.WEAR_URI_SCHEME)
+            .authority("*")
+            .path(WearDataPaths.WEAR_PERFORMANCE_SETTINGS)
+            .build()
+        val buffer = dataClient.getDataItems(uri, DataClient.FILTER_PREFIX).await()
+        try {
+            val dataMap = buffer.firstOrNull()?.let { DataMapItem.fromDataItem(it).dataMap } ?: run {
+                Timber.tag(TAG).d("No performance settings DataItem published by the phone yet")
+                return
+            }
+            val showAlbumArt = dataMap.getBoolean(WearDataPaths.KEY_SHOW_ALBUM_ART, true)
+            val dynamicColorTheming = dataMap.getBoolean(WearDataPaths.KEY_DYNAMIC_COLOR_THEMING, true)
+            val playButtonAnimation = dataMap.getBoolean(WearDataPaths.KEY_PLAY_BUTTON_ANIMATION, true)
+            save(showAlbumArt, dynamicColorTheming, playButtonAnimation)
+            Timber.tag(TAG).i(
+                "Performance settings refreshed from phone: albumArt=%s dynamicColor=%s playButtonAnim=%s",
+                showAlbumArt,
+                dynamicColorTheming,
+                playButtonAnimation,
+            )
+        } finally {
+            buffer.release()
+        }
+    }
+
     suspend fun save(showAlbumArt: Boolean, dynamicColorTheming: Boolean, playButtonAnimation: Boolean) {
         dataStore.edit { prefs ->
             prefs[Keys.SHOW_ALBUM_ART] = showAlbumArt
             prefs[Keys.DYNAMIC_COLOR_THEMING] = dynamicColorTheming
             prefs[Keys.PLAY_BUTTON_ANIMATION] = playButtonAnimation
         }
+    }
+
+    private companion object {
+        const val TAG = "WearPerfSettings"
     }
 
     private object Keys {

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepository.kt
@@ -12,10 +12,14 @@ import com.theveloper.pixelplay.shared.WearDataPaths
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 import javax.inject.Inject
@@ -41,6 +45,29 @@ class WearPerformanceSettingsRepository @Inject constructor(
     private val dataClient: DataClient,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _isResolved = MutableStateFlow(false)
+
+    /**
+     * Whether the toggles below can be trusted yet.
+     *
+     * Reading them before this is `true` gives whatever the watch had cached last, which
+     * [refreshFromPhone] may be about to overturn — and acting on that guess is visible: playback
+     * starts, the album art and its adapted colors appear, and a second later the refresh lands
+     * and rips them away again. Consumers treat "not resolved yet" as off, so the expensive work
+     * is deferred rather than done and undone.
+     */
+    val isResolved: StateFlow<Boolean> = _isResolved.asStateFlow()
+
+    init {
+        // Safety net so an unresolved state can never be permanent: if refreshFromPhone() is
+        // never called, or its process is torn down before it finishes, the toggles fall back to
+        // the cached values rather than suppressing album art forever.
+        scope.launch {
+            delay(RESOLVE_DEADLINE_MS)
+            _isResolved.value = true
+        }
+    }
 
     val showAlbumArt: StateFlow<Boolean> = dataStore.data
         .map { it[Keys.SHOW_ALBUM_ART] ?: true }
@@ -71,6 +98,16 @@ class WearPerformanceSettingsRepository @Inject constructor(
      * has never opened the phone's watch settings (no DataItem, defaults stand).
      */
     suspend fun refreshFromPhone() {
+        try {
+            readAndApplyPublishedSettings()
+        } finally {
+            // Resolved either way: a failed lookup means "the cached values are all we'll ever
+            // have", which is a resolved answer as far as consumers are concerned.
+            _isResolved.value = true
+        }
+    }
+
+    private suspend fun readAndApplyPublishedSettings() {
         // Wildcard host to match the item whichever node published it, and FILTER_PREFIX rather
         // than an exact literal match so the lookup can't miss over a trailing-path detail.
         val uri = Uri.Builder()
@@ -109,6 +146,11 @@ class WearPerformanceSettingsRepository @Inject constructor(
 
     private companion object {
         const val TAG = "WearPerfSettings"
+
+        // Only reached if refreshFromPhone() never completes. Long enough that the normal path
+        // (a local Play Services lookup, started at process creation) always wins the race, short
+        // enough that the pathological case isn't a visibly art-less app.
+        const val RESOLVE_DEADLINE_MS = 4_000L
     }
 
     private object Keys {

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepository.kt
@@ -1,0 +1,62 @@
+package com.theveloper.pixelplay.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Watch-side durable cache of the performance toggles configured from the phone's Settings ->
+ * "Reloj" screen. [WearDataListenerService] writes into this whenever a
+ * `WearDataPaths.WEAR_PERFORMANCE_SETTINGS` DataItem syncs in; [WearLocalPlayerRepository] and the
+ * player UI read it reactively. Caching locally (rather than querying the phone live) is the
+ * whole point — these need to apply during standalone local playback, exactly when the phone may
+ * not be reachable at all.
+ *
+ * All three default to `true` — current behavior preserved for a watch that's never received a
+ * sync (e.g. right after this feature ships, before the user opens the new phone settings screen).
+ *
+ * Only meaningful during local playback (`WearOutputTarget.WATCH`) — see call sites for why
+ * remote-controller mode ignores these entirely.
+ */
+@Singleton
+class WearPerformanceSettingsRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    val showAlbumArt: StateFlow<Boolean> = dataStore.data
+        .map { it[Keys.SHOW_ALBUM_ART] ?: true }
+        .stateIn(scope, SharingStarted.Eagerly, true)
+
+    val dynamicColorTheming: StateFlow<Boolean> = dataStore.data
+        .map { it[Keys.DYNAMIC_COLOR_THEMING] ?: true }
+        .stateIn(scope, SharingStarted.Eagerly, true)
+
+    val playButtonAnimation: StateFlow<Boolean> = dataStore.data
+        .map { it[Keys.PLAY_BUTTON_ANIMATION] ?: true }
+        .stateIn(scope, SharingStarted.Eagerly, true)
+
+    suspend fun save(showAlbumArt: Boolean, dynamicColorTheming: Boolean, playButtonAnimation: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[Keys.SHOW_ALBUM_ART] = showAlbumArt
+            prefs[Keys.DYNAMIC_COLOR_THEMING] = dynamicColorTheming
+            prefs[Keys.PLAY_BUTTON_ANIMATION] = playButtonAnimation
+        }
+    }
+
+    private object Keys {
+        val SHOW_ALBUM_ART = booleanPreferencesKey("wear_perf_show_album_art")
+        val DYNAMIC_COLOR_THEMING = booleanPreferencesKey("wear_perf_dynamic_color_theming")
+        val PLAY_BUTTON_ANIMATION = booleanPreferencesKey("wear_perf_play_button_animation")
+    }
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackService.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackService.kt
@@ -1,15 +1,31 @@
 package com.theveloper.pixelplay.data
 
+import android.app.ActivityManager
 import android.app.PendingIntent
 import android.content.Intent
+import android.os.SystemClock
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.extractor.mp4.Mp4Extractor
+import androidx.media3.extractor.text.SubtitleParser
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /**
@@ -28,31 +44,33 @@ class WearPlaybackService : MediaSessionService() {
 
     private var player: ExoPlayer? = null
     private var mediaSession: MediaSession? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    // --- Audio offload state -------------------------------------------------------------
+    // AUDIO_OFFLOAD_MODE_ENABLED (as opposed to _REQUIRED) is a *soft* request: if the watch's
+    // audio HAL doesn't support offloading this format, ExoPlayer silently falls back to the
+    // normal decode path on its own — no capability probing needed on our side for that case.
+    // What ExoPlayer *doesn't* handle on its own is a HAL that accepts the offloaded track but
+    // then resets/stalls — that failure mode is exactly what motivated the phone's
+    // DualPlayerEngine to build a runtime fallback (see AudioOffloadPolicyTest in :app), so this
+    // service mirrors that safety net rather than assuming Wear OS audio HALs are better-behaved.
+    private var audioOffloadEnabled = true
+    private var lastPlayingAtMs = 0L
+    private var isPostSeekBuffering = false
+    private var isPostMediaItemTransition = false
+
+    // --- Mid-song stall watchdog ----------------------------------------------------------
+    // See WearPlaybackStallWatchdog.kt: catches a stall AudioOffloadFallbackListener can't, one
+    // that happens well after playback started and never surfaces as STATE_BUFFERING.
+    private var stallWatchdogJob: Job? = null
+    private var lastWatchdogPositionMs = -1L
+    private var consecutiveStalledTicks = 0
 
     override fun onCreate() {
         super.onCreate()
-
-        val exoPlayer = ExoPlayer.Builder(this)
-            .setAudioAttributes(
-                AudioAttributes.Builder()
-                    .setUsage(C.USAGE_MEDIA)
-                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
-                    .build(),
-                /* handleAudioFocus = */ true,
-            )
-            .setHandleAudioBecomingNoisy(true)
-            // Keep the CPU running while the watch dozes with the screen off, otherwise audio
-            // decoding stalls a few seconds after the display turns off.
-            .setWakeMode(C.WAKE_MODE_LOCAL)
-            .build()
-        player = exoPlayer
-
-        mediaSession = MediaSession.Builder(this, exoPlayer)
-            .setId(MEDIA_SESSION_ID)
-            .setSessionActivity(buildOpenAppIntent())
-            .setCallback(MediaItemUriRestoringCallback())
-            .build()
-
+        player = buildExoPlayer()
+        mediaSession = buildMediaSession(player!!)
+        startStallWatchdog()
         Timber.tag(TAG).d("WearPlaybackService created")
     }
 
@@ -67,12 +85,178 @@ class WearPlaybackService : MediaSessionService() {
     }
 
     override fun onDestroy() {
+        stallWatchdogJob?.cancel()
+        scope.cancel()
         mediaSession?.release()
         mediaSession = null
         player?.release()
         player = null
         Timber.tag(TAG).d("WearPlaybackService destroyed")
         super.onDestroy()
+    }
+
+    private fun buildExoPlayer(): ExoPlayer {
+        val isLowRamDevice = getSystemService(ActivityManager::class.java)?.isLowRamDevice == true
+        val bufferProfile = wearLoadControlBufferProfileFor(isLowRamDevice)
+        val loadControl = DefaultLoadControl.Builder()
+            .setBufferDurationsMs(
+                bufferProfile.minBufferMs,
+                bufferProfile.maxBufferMs,
+                bufferProfile.bufferForPlaybackMs,
+                bufferProfile.bufferForPlaybackAfterRebufferMs,
+            )
+            // Buffered *duration*, not buffered *bytes*, decides when to (re)start playback —
+            // matches the phone's DualPlayerEngine and is what makes the profile above meaningful
+            // across formats/bitrates instead of being overridden by ExoPlayer's byte threshold.
+            .setPrioritizeTimeOverSizeThresholds(true)
+            .build()
+
+        val exoPlayer = ExoPlayer.Builder(this)
+            .setLoadControl(loadControl)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                    .build(),
+                /* handleAudioFocus = */ true,
+            )
+            .setHandleAudioBecomingNoisy(true)
+            // Keep the CPU running while the watch dozes with the screen off, otherwise audio
+            // decoding stalls a few seconds after the display turns off.
+            .setWakeMode(C.WAKE_MODE_LOCAL)
+            // The default DefaultMediaSourceFactory registers ~15 extractor types (Matroska,
+            // FLV, AVI, MPEG-TS…) that this service never plays — every file here comes from
+            // [WatchAudioTranscoder] on the phone, which always writes plain (non-fragmented)
+            // MP4/AAC-LC. ART verifies each extractor class the first time DefaultExtractorsFactory
+            // touches it while sniffing the container, on the main thread; measured on-device this
+            // cost 120-300ms per unused class, ~2s total, stacked right on top of playback start.
+            // Scoping the factory to the one extractor we actually need removes that cost entirely.
+            .setMediaSourceFactory(
+                // Every other Mp4Extractor constructor/factory in this media3 version is
+                // deprecated in favor of newFactory(SubtitleParser.Factory); our files are
+                // audio-only, so subtitle parsing is simply unsupported.
+                DefaultMediaSourceFactory(this, Mp4Extractor.newFactory(SubtitleParser.Factory.UNSUPPORTED))
+            )
+            .build()
+        exoPlayer.trackSelectionParameters = trackSelectionParametersFor(audioOffloadEnabled)
+        exoPlayer.addListener(AudioOffloadFallbackListener())
+        return exoPlayer
+    }
+
+    private fun trackSelectionParametersFor(offloadEnabled: Boolean): TrackSelectionParameters {
+        return TrackSelectionParameters.DEFAULT.buildUpon()
+            .setAudioOffloadPreferences(
+                TrackSelectionParameters.AudioOffloadPreferences.Builder()
+                    .setAudioOffloadMode(
+                        if (offloadEnabled) {
+                            TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED
+                        } else {
+                            TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_DISABLED
+                        }
+                    )
+                    .setIsGaplessSupportRequired(false)
+                    .setIsSpeedChangeSupportRequired(false)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun buildMediaSession(exoPlayer: ExoPlayer): MediaSession {
+        return MediaSession.Builder(this, exoPlayer)
+            .setId(MEDIA_SESSION_ID)
+            .setSessionActivity(buildOpenAppIntent())
+            .setCallback(MediaItemUriRestoringCallback())
+            .build()
+    }
+
+    /**
+     * Rebuilds the player after [AudioOffloadFallbackListener] reads an early re-buffer as a HAL
+     * reset, disabling offload for the rest of the session.
+     */
+    private fun fallBackFromAudioOffload(reason: String) {
+        if (!audioOffloadEnabled) return
+        audioOffloadEnabled = false
+        Timber.tag(TAG).w("Falling back from audio offload: %s", reason)
+        rebuildPlayerPreservingState()
+    }
+
+    /**
+     * Rebuilds the player after the stall watchdog sees position frozen for
+     * [STALL_TICKS_THRESHOLD] ticks in a row — the *mid-song* wedge [fallBackFromAudioOffload]
+     * can't see (see WearPlaybackStallWatchdog.kt). Unlike that early check, this doesn't gate on
+     * [audioOffloadEnabled]: if offload is still on, disabling it too is the best available guess
+     * at the cause, but the rebuild itself — a fresh ExoPlayer/AudioTrack instance — is the actual
+     * fix regardless, so it still runs even if offload was already off from an earlier fallback.
+     */
+    private fun recoverFromStalledPlayback(reason: String) {
+        Timber.tag(TAG).w("Recovering from stalled playback: %s", reason)
+        audioOffloadEnabled = false
+        rebuildPlayerPreservingState()
+    }
+
+    /**
+     * Preserves queue/position/play-state across a player rebuild. [MediaSession.setPlayer] lets
+     * the existing session (and any connected `MediaController`, including the phone acting as a
+     * remote) keep its binder connection across the swap instead of tearing down and
+     * reconnecting — the rebuild is invisible to callers beyond a brief re-buffer.
+     */
+    private fun rebuildPlayerPreservingState() {
+        val oldPlayer = player ?: return
+
+        val mediaItems = ArrayList<MediaItem>(oldPlayer.mediaItemCount)
+        for (i in 0 until oldPlayer.mediaItemCount) mediaItems.add(oldPlayer.getMediaItemAt(i))
+        val currentIndex = oldPlayer.currentMediaItemIndex.coerceAtLeast(0)
+        val positionMs = oldPlayer.currentPosition.coerceAtLeast(0L)
+        val playWhenReady = oldPlayer.playWhenReady
+        val repeatMode = oldPlayer.repeatMode
+        val shuffleModeEnabled = oldPlayer.shuffleModeEnabled
+
+        val newPlayer = buildExoPlayer()
+        if (mediaItems.isNotEmpty()) {
+            newPlayer.setMediaItems(mediaItems, currentIndex, positionMs)
+            newPlayer.repeatMode = repeatMode
+            newPlayer.shuffleModeEnabled = shuffleModeEnabled
+            newPlayer.prepare()
+            newPlayer.playWhenReady = playWhenReady
+        }
+
+        player = newPlayer
+        mediaSession?.setPlayer(newPlayer)
+        oldPlayer.release()
+
+        // The new player instance starts wherever setMediaItems/positionMs put it — don't let a
+        // stale reading from the old (just-released) player count as "no progress" against it.
+        lastWatchdogPositionMs = -1L
+        consecutiveStalledTicks = 0
+    }
+
+    /**
+     * Ticks once a second, comparing the player's own reported position against the last tick's —
+     * a stall that doesn't change [Player.getPlaybackState] (see WearPlaybackStallWatchdog.kt)
+     * has no listener callback to hook, so this is the only way to catch it.
+     */
+    private fun startStallWatchdog() {
+        stallWatchdogJob?.cancel()
+        stallWatchdogJob = scope.launch {
+            while (isActive) {
+                delay(STALL_TICK_INTERVAL_MS)
+                val current = player ?: continue
+                val isPlaying = current.isPlaying
+                val position = current.currentPosition
+                val positionAdvanced = position != lastWatchdogPositionMs
+                lastWatchdogPositionMs = position
+                consecutiveStalledTicks = wearPlaybackStalledTickCount(
+                    isPlaying = isPlaying,
+                    positionAdvancedSinceLastTick = positionAdvanced,
+                    previousConsecutiveStalledTicks = consecutiveStalledTicks,
+                )
+                if (consecutiveStalledTicks >= STALL_TICKS_THRESHOLD) {
+                    recoverFromStalledPlayback(
+                        "no position advance for ${STALL_TICK_INTERVAL_MS * STALL_TICKS_THRESHOLD}ms"
+                    )
+                }
+            }
+        }
     }
 
     private fun buildOpenAppIntent(): PendingIntent {
@@ -85,6 +269,50 @@ class WearPlaybackService : MediaSessionService() {
             launchIntent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
+    }
+
+    /**
+     * Watches for the early-buffering pattern [wearShouldFallBackFromAudioOffload] recognizes as
+     * an offload HAL reset, and triggers [fallBackFromAudioOffload] when it does.
+     */
+    private inner class AudioOffloadFallbackListener : Player.Listener {
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (isPlaying) {
+                lastPlayingAtMs = SystemClock.elapsedRealtime()
+                isPostSeekBuffering = false
+                isPostMediaItemTransition = false
+            }
+        }
+
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int,
+        ) {
+            if (reason == Player.DISCONTINUITY_REASON_SEEK) {
+                isPostSeekBuffering = true
+            }
+        }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            isPostMediaItemTransition = true
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState != Player.STATE_BUFFERING) return
+            val now = SystemClock.elapsedRealtime()
+            val shouldFallBack = wearShouldFallBackFromAudioOffload(
+                audioOffloadEnabled = audioOffloadEnabled,
+                lastPlayingAtMs = lastPlayingAtMs,
+                timeSincePlayingMs = now - lastPlayingAtMs,
+                isPostSeekBuffering = isPostSeekBuffering,
+                isPostMediaItemTransition = isPostMediaItemTransition,
+            )
+            if (shouldFallBack) {
+                fallBackFromAudioOffload("early re-buffer ${now - lastPlayingAtMs}ms after playing")
+            }
+        }
     }
 
     /**
@@ -114,5 +342,11 @@ class WearPlaybackService : MediaSessionService() {
     companion object {
         private const val TAG = "WearPlaybackService"
         private const val MEDIA_SESSION_ID = "wear-local-playback"
+
+        // 3 consecutive 1s ticks with zero position movement while isPlaying=true — long enough
+        // that a legitimate single slow tick can't false-positive, short enough that a real wedge
+        // doesn't sit silent for long before recovering.
+        private const val STALL_TICK_INTERVAL_MS = 1_000L
+        private const val STALL_TICKS_THRESHOLD = 3
     }
 }

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackStallWatchdog.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackStallWatchdog.kt
@@ -1,0 +1,30 @@
+package com.theveloper.pixelplay.data
+
+/**
+ * Detects a playback stall that [wearShouldFallBackFromAudioOffload] can't see.
+ *
+ * That check only reacts to a stall within ~500ms of *starting* playback, surfaced as
+ * `STATE_BUFFERING` — the pattern the phone's `DualPlayerEngine` originally guarded against. Real
+ * hardware testing on the watch (a Samsung Galaxy Watch) showed a different failure: the offload
+ * HAL wedges *mid-song*, well past that early window, and the player's own reported state never
+ * changes — it stays `STATE_READY` / `isPlaying=true` (the AudioTrack has simply stopped draining
+ * what ExoPlayer feeds it). That's consistent with what was observed: `play()` does nothing once
+ * this happens (from the player's point of view, `playWhenReady` is already `true` — there's
+ * nothing to resume), while `seekToNext()` still works (it tears down and rebuilds the sink for
+ * the new item, sidestepping the wedged one — and then wedges again on that new item too, since
+ * whatever the underlying condition is hasn't changed).
+ *
+ * Since there's no state transition to hook, this is driven by a timer polling the player's own
+ * reported position instead: called once per tick while ticking at a fixed interval (see
+ * [WearPlaybackService]), it turns "did the position actually move since last tick" into a
+ * consecutive-stall counter, so a real freeze (not just a brief legitimate pause in advancing) is
+ * required before anything reacts.
+ */
+internal fun wearPlaybackStalledTickCount(
+    isPlaying: Boolean,
+    positionAdvancedSinceLastTick: Boolean,
+    previousConsecutiveStalledTicks: Int,
+): Int {
+    if (!isPlaying || positionAdvancedSinceLastTick) return 0
+    return previousConsecutiveStalledTicks + 1
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackStatePersistence.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackStatePersistence.kt
@@ -1,0 +1,100 @@
+package com.theveloper.pixelplay.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+/** Watch-side DataStore, separate from the phone's — the two processes never share one file. */
+val Context.wearDataStore: DataStore<Preferences> by preferencesDataStore(name = "wear_settings")
+
+/**
+ * The watch's local-playback queue and position, in just enough detail to restore it, paused,
+ * after the hosting process dies mid-playback.
+ *
+ * Confirmed on-device this session, not a theoretical concern: the app's process was recycled
+ * during a system-wide low-memory episode while a fitness-tracking app ran alongside local
+ * playback (PID changed across ~90s in which 23 other system processes were also killed for
+ * memory). `WearPlaybackService` being a foreground `MediaSessionService` makes that less likely,
+ * not impossible — Wear OS watches have very little RAM to begin with.
+ */
+@Serializable
+data class PersistedLocalPlaybackState(
+    val queueSongIds: List<String>,
+    val currentIndex: Int,
+    val positionMs: Long,
+    val updatedAtMillis: Long,
+)
+
+/**
+ * Persists at most one in-flight local-playback queue — mirrors
+ * `PlaylistBatchTransferPersistence` in `:app` (same DataStore-backed, single-slot,
+ * JSON-via-kotlinx.serialization shape), adapted to the watch's own DataStore since `:wear` and
+ * `:app` are separate processes with no shared storage.
+ */
+@Singleton
+class WearPlaybackStatePersistence @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun save(state: PersistedLocalPlaybackState) {
+        dataStore.edit { preferences ->
+            preferences[Keys.LOCAL_PLAYBACK_STATE] = json.encodeToString(state)
+        }
+    }
+
+    suspend fun clear() {
+        dataStore.edit { preferences -> preferences.remove(Keys.LOCAL_PLAYBACK_STATE) }
+    }
+
+    suspend fun read(): PersistedLocalPlaybackState? {
+        val stored = dataStore.data.first()[Keys.LOCAL_PLAYBACK_STATE] ?: return null
+        return try {
+            json.decodeFromString<PersistedLocalPlaybackState>(stored)
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Failed to decode persisted local playback state, discarding it")
+            null
+        }
+    }
+
+    private object Keys {
+        val LOCAL_PLAYBACK_STATE = stringPreferencesKey("wear_local_playback_state_v1")
+    }
+
+    private companion object {
+        const val TAG = "WearPlaybackPersist"
+    }
+}
+
+/**
+ * Whether a persisted queue is still worth restoring.
+ *
+ * Requires at least one song id (an empty queue is nothing to resume) and caps how stale the
+ * snapshot can be: recovering from a crash a few minutes or hours ago is the point of this
+ * (§R-06-adjacent — the phone-side batch-transfer persistence uses the same "was genuinely
+ * in-flight" reasoning); silently resurrecting whatever was playing days ago the next time the
+ * app happens to open would be surprising rather than helpful. There's no on-device data to
+ * calibrate the exact cutoff, so this picks a conservative, generously-long window instead of a
+ * precisely-tuned one.
+ */
+internal fun isPersistedLocalPlaybackStateRestorable(
+    state: PersistedLocalPlaybackState,
+    nowMillis: Long,
+    maxAgeMillis: Long = 6 * 60 * 60 * 1000L,
+): Boolean {
+    if (state.queueSongIds.isEmpty()) return false
+    if (state.currentIndex !in state.queueSongIds.indices) return false
+    val ageMillis = nowMillis - state.updatedAtMillis
+    return ageMillis in 0..maxAgeMillis
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
@@ -6,10 +6,15 @@ import android.webkit.MimeTypeMap
 import com.google.android.gms.wearable.ChannelClient
 import com.google.android.gms.wearable.MessageClient
 import com.google.android.gms.wearable.NodeClient
+import com.theveloper.pixelplay.data.local.LocalPlaylistDao
+import com.theveloper.pixelplay.data.local.LocalPlaylistEntity
+import com.theveloper.pixelplay.data.local.LocalPlaylistSongCrossRef
 import com.theveloper.pixelplay.data.local.LocalSongDao
 import com.theveloper.pixelplay.data.local.LocalSongEntity
 import com.theveloper.pixelplay.shared.WearDataPaths
 import com.theveloper.pixelplay.shared.WearLibraryState
+import com.theveloper.pixelplay.shared.WearPlaylistSync
+import com.theveloper.pixelplay.shared.WearPlaylistSyncAck
 import com.theveloper.pixelplay.shared.WearTransferMetadata
 import com.theveloper.pixelplay.shared.WearTransferProgress
 import com.theveloper.pixelplay.shared.WearTransferRequest
@@ -70,6 +75,7 @@ data class TransferState(
 class WearTransferRepository @Inject constructor(
     private val application: Application,
     private val localSongDao: LocalSongDao,
+    private val localPlaylistDao: LocalPlaylistDao,
     private val channelClient: ChannelClient,
     private val messageClient: MessageClient,
     private val nodeClient: NodeClient,
@@ -110,6 +116,13 @@ class WearTransferRepository @Inject constructor(
     /** Pending metadata awaiting channel stream: requestId -> metadata */
     private val pendingMetadata = ConcurrentHashMap<String, WearTransferMetadata>()
 
+    /**
+     * requestId -> the node this request came from, recorded as soon as metadata arrives so
+     * later stages (audio-channel success/failure, the idle watchdog) can report the real
+     * outcome back to the phone without having to thread a nodeId through every call site.
+     */
+    private val requestIdToSourceNode = ConcurrentHashMap<String, String>()
+
     /** Mapping from songId -> requestId for tracking which song is being transferred */
     private val songToRequestId = ConcurrentHashMap<String, String>()
 
@@ -120,6 +133,13 @@ class WearTransferRepository @Inject constructor(
 
     /** Failsafe timeout per transfer to avoid hanging states at 0%. */
     private val transferWatchdogs = ConcurrentHashMap<String, Job>()
+    /** The live audio InputStream for a request, while onAudioChannelOpened is reading it —
+     *  lets armTransferWatchdog actually interrupt a stuck read instead of just updating
+     *  bookkeeping while the real transfer keeps running unaware. */
+    private val openAudioStreams = ConcurrentHashMap<String, InputStream>()
+    /** Request IDs whose audio stream was closed by the watchdog, so onAudioChannelOpened's
+     *  catch block can report "Transfer timed out" instead of a generic stream-closed message. */
+    private val watchdogTimedOutRequestIds = ConcurrentHashMap.newKeySet<String>()
     /** Request IDs currently receiving bytes through ChannelClient. */
     private val activeChannelRequestIds = ConcurrentHashMap.newKeySet<String>()
     /** Cancelled request IDs retained briefly so late metadata/progress/channel events are ignored safely. */
@@ -288,6 +308,34 @@ class WearTransferRepository @Inject constructor(
             songId,
             message,
         )
+        notifyPhoneTransferOutcome(
+            targetNodeId = targetNodeId,
+            requestId = requestId,
+            songId = songId,
+            status = WearTransferProgress.STATUS_FAILED,
+            error = message,
+        )
+    }
+
+    /**
+     * Tells the phone what actually happened to a transfer, over the same
+     * [WearDataPaths.TRANSFER_PROGRESS] path the phone uses to push its own send-side progress —
+     * the phone side ([com.theveloper.pixelplay.data.service.wear.WearCommandReceiver], app
+     * module) has a matching handler for messages arriving *from* the watch on this path. This is
+     * the only source of truth the phone trusts for whether a save-to-library transfer really
+     * landed: the phone no longer marks a song "present on watch" purely because it finished
+     * writing bytes to the channel — see `PhoneDirectWatchTransferCoordinator.streamFileToWatch`.
+     * Best-effort: if this message itself gets lost, the phone's own await timeout in
+     * `PlaylistWatchTransferCoordinator.transferSongToNode` still fails the request instead of
+     * hanging forever, and the coordinator's existing retry-once logic picks it up from there.
+     */
+    private suspend fun notifyPhoneTransferOutcome(
+        targetNodeId: String?,
+        requestId: String,
+        songId: String,
+        status: String,
+        error: String? = null,
+    ) {
         if (targetNodeId == null) return
 
         runCatching {
@@ -296,16 +344,16 @@ class WearTransferRepository @Inject constructor(
                 songId = songId,
                 bytesTransferred = 0L,
                 totalBytes = 0L,
-                status = WearTransferProgress.STATUS_FAILED,
-                error = message,
+                status = status,
+                error = error,
             )
             messageClient.sendMessage(
                 targetNodeId,
                 WearDataPaths.TRANSFER_PROGRESS,
                 json.encodeToString(progress).toByteArray(Charsets.UTF_8),
             ).await()
-        }.onFailure { error ->
-            Timber.tag(TAG).w(error, "Failed to report transfer failure to phone")
+        }.onFailure { sendError ->
+            Timber.tag(TAG).w(sendError, "Failed to report transfer outcome (%s) to phone", status)
         }
     }
 
@@ -316,6 +364,9 @@ class WearTransferRepository @Inject constructor(
         metadata: WearTransferMetadata,
         sourceNodeId: String? = null,
     ) {
+        if (sourceNodeId != null) {
+            requestIdToSourceNode[metadata.requestId] = sourceNodeId
+        }
         if (isTransferCancelled(metadata.requestId)) {
             cleanupCancelledTransfer(metadata.requestId, metadata.songId)
             return
@@ -331,12 +382,8 @@ class WearTransferRepository @Inject constructor(
             metadata.transferMode == WearTransferRequest.MODE_SAVE_TO_LIBRARY &&
             existingSong?.hasPlayableLocalFile() == true
         ) {
-            notifyPhoneTransferFailure(
-                targetNodeId = sourceNodeId,
-                requestId = metadata.requestId,
-                songId = metadata.songId,
-                message = WearTransferProgress.ERROR_ALREADY_ON_WATCH,
-            )
+            // handleTransferError() below reports this outcome to the phone itself now, using
+            // requestIdToSourceNode (populated a few lines up) — no separate notify call needed.
             handleTransferError(
                 requestId = metadata.requestId,
                 songId = metadata.songId,
@@ -347,6 +394,14 @@ class WearTransferRepository @Inject constructor(
 
         pendingMetadata[metadata.requestId] = metadata
         armTransferWatchdog(metadata.requestId, metadata.songId)
+        if (sourceNodeId != null) {
+            notifyPhoneTransferOutcome(
+                targetNodeId = sourceNodeId,
+                requestId = metadata.requestId,
+                songId = metadata.songId,
+                status = WearTransferProgress.STATUS_METADATA_RECEIVED,
+            )
+        }
         _activeTransfers.update { map ->
             val current = map[metadata.requestId] ?: TransferState(
                 requestId = metadata.requestId,
@@ -406,7 +461,9 @@ class WearTransferRepository @Inject constructor(
         }
 
         if (normalizedStatus == WearTransferProgress.STATUS_FAILED) {
-            handleTransferError(progress.requestId, progress.songId, progress.error ?: "Transfer failed")
+            val songId = progress.songId
+            val error = progress.error ?: "Transfer failed"
+            scope.launch { handleTransferError(progress.requestId, songId, error) }
         } else if (
             normalizedStatus == WearTransferProgress.STATUS_COMPLETED ||
             normalizedStatus == WearTransferProgress.STATUS_CANCELLED
@@ -483,6 +540,7 @@ class WearTransferRepository @Inject constructor(
         if (!musicDir.exists()) musicDir.mkdirs()
         val tempFile = File(musicDir, "$requestId.part")
         var metadata: WearTransferMetadata? = pendingMetadata[requestId]
+        openAudioStreams[requestId] = inputStream
 
         try {
             if (isTransferCancelled(requestId)) {
@@ -685,6 +743,10 @@ class WearTransferRepository @Inject constructor(
                 _activeTransfers.update { it - requestId }
                 songToRequestId.remove(resolvedMetadata.songId)
                 clearTransferWatchdog(requestId)
+                // Temporary playback doesn't participate in the phone's "is this song saved on
+                // watch" bookkeeping, so it skips the outcome round-trip — just drop the
+                // now-unneeded node mapping.
+                requestIdToSourceNode.remove(requestId)
                 Timber.tag(TAG).d(
                     "Temporary playback ready: %s (%d bytes) → %s",
                     resolvedMetadata.title,
@@ -760,19 +822,34 @@ class WearTransferRepository @Inject constructor(
             songToRequestId.remove(resolvedMetadata.songId)
             clearTransferWatchdog(requestId)
 
+            // Only now — file written and inserted into Room, genuinely playable — does the
+            // phone get told this landed. It's what unblocks PlaylistWatchTransferCoordinator's
+            // await and is the only trigger for markSongPresentOnWatch() on the phone side.
+            requestIdToSourceNode.remove(requestId)?.let { nodeId ->
+                notifyPhoneTransferOutcome(
+                    targetNodeId = nodeId,
+                    requestId = requestId,
+                    songId = resolvedMetadata.songId,
+                    status = WearTransferProgress.STATUS_COMPLETED,
+                )
+            }
+
             Timber.tag(TAG).d(
                 "Transfer complete: ${resolvedMetadata.title} ($actualSize bytes) → ${localFile.absolutePath}"
             )
         } catch (e: Exception) {
+            val timedOut = watchdogTimedOutRequestIds.remove(requestId)
             Timber.tag(TAG).e(e, "Failed to write transferred file")
             tempFile.delete()
             handleTransferError(
                 requestId = requestId,
                 songId = metadata?.songId ?: _activeTransfers.value[requestId]?.songId.orEmpty(),
-                message = e.message ?: "Write failed",
+                message = if (timedOut) "Transfer timed out" else (e.message ?: "Write failed"),
             )
         } finally {
             activeChannelRequestIds.remove(requestId)
+            openAudioStreams.remove(requestId)
+            watchdogTimedOutRequestIds.remove(requestId)
         }
     }
 
@@ -835,6 +912,21 @@ class WearTransferRepository @Inject constructor(
         }
     }
 
+    /**
+     * Clears a finished (failed/cancelled) transfer from [activeTransfers] so its chip stops
+     * showing in the Downloads screen's "issues" section. Purely a local UI dismissal — doesn't
+     * touch the phone's own bookkeeping of what's actually saved, which already reflects reality
+     * independently (see [notifyPhoneTransferOutcome]). Safe to call for any requestId; a no-op
+     * if it's already gone or still in progress (nothing to dismiss either way).
+     */
+    fun dismissTransfer(requestId: String) {
+        _activeTransfers.update { map ->
+            val current = map[requestId] ?: return@update map
+            if (current.status == WearTransferProgress.STATUS_TRANSFERRING) return@update map
+            map - requestId
+        }
+    }
+
     suspend fun publishLibraryState(
         targetNodeId: String? = null,
         songIds: Set<String>? = null,
@@ -863,6 +955,62 @@ class WearTransferRepository @Inject constructor(
             }
         }.onFailure { error ->
             Timber.tag(TAG).w(error, "Failed to publish watch library state")
+        }
+    }
+
+    /**
+     * Called when a playlist sync arrives from the phone — sent once up front, before any of its
+     * songs' audio has necessarily finished transferring, so the watch can show the playlist and
+     * start playing whatever's already local right away. Idempotent: re-syncing the same
+     * [WearPlaylistSync.playlistId] (e.g. after the user edits the playlist on the phone) replaces
+     * membership/order in one transaction rather than merging with the stale cross-refs.
+     *
+     * [sourceNodeId] is where the ack goes back to. Acking is best-effort and never blocks or
+     * fails this function — if [WearPlaylistSync.requestId] is empty (an old phone build) there's
+     * nothing to correlate an ack to, so none is sent.
+     */
+    suspend fun onPlaylistSyncReceived(sync: WearPlaylistSync, sourceNodeId: String) {
+        val now = System.currentTimeMillis()
+        val existing = localPlaylistDao.getPlaylistById(sync.playlistId)
+        val entity = LocalPlaylistEntity(
+            playlistId = sync.playlistId,
+            name = sync.name,
+            createdAt = existing?.createdAt ?: now,
+            updatedAt = now,
+        )
+        val crossRefs = sync.songIds.mapIndexed { index, songId ->
+            LocalPlaylistSongCrossRef(
+                playlistId = sync.playlistId,
+                songId = songId,
+                position = index,
+                // songTitles is a parallel list to songIds; an older phone build omits it
+                // entirely (defaults to emptyList()), so this falls back to "" per song rather
+                // than crashing on an index that isn't there.
+                pendingTitle = sync.songTitles.getOrElse(index) { "" },
+            )
+        }
+        localPlaylistDao.upsertPlaylist(entity, crossRefs)
+        Timber.tag(TAG).d(
+            "Playlist synced: %s (%d songs)",
+            sync.name,
+            sync.songIds.size,
+        )
+
+        if (sync.requestId.isNotEmpty()) {
+            sendPlaylistSyncAck(sourceNodeId, sync.playlistId, sync.requestId)
+        }
+    }
+
+    private suspend fun sendPlaylistSyncAck(nodeId: String, playlistId: String, requestId: String) {
+        val ack = WearPlaylistSyncAck(playlistId = playlistId, requestId = requestId)
+        try {
+            val ackBytes = json.encodeToString(ack).toByteArray(Charsets.UTF_8)
+            messageClient.sendMessage(nodeId, WearDataPaths.PLAYLIST_SYNC_ACK, ackBytes).await()
+        } catch (e: Exception) {
+            // Not retried here: if this is lost too, the phone's own await-ack timeout fires and
+            // it resends the whole sync, which is idempotent — so the watch just gets another shot
+            // at acking rather than needing its own retry logic for the ack itself.
+            Timber.tag(TAG).w(e, "Failed to send playlist sync ack: playlistId=%s", playlistId)
         }
     }
 
@@ -941,9 +1089,11 @@ class WearTransferRepository @Inject constructor(
         pendingArtworkByRequestId.remove(requestId)
         clearTransferWatchdog(requestId)
         activeChannelRequestIds.remove(requestId)
+        openAudioStreams.remove(requestId)
+        watchdogTimedOutRequestIds.remove(requestId)
     }
 
-    private fun handleTransferError(requestId: String, songId: String, message: String) {
+    private suspend fun handleTransferError(requestId: String, songId: String, message: String) {
         Timber.tag(TAG).e("Transfer error: $message (requestId=$requestId, songId=$songId)")
         _activeTransfers.update { map ->
             val current = map[requestId]
@@ -962,6 +1112,21 @@ class WearTransferRepository @Inject constructor(
         pendingArtworkByRequestId.remove(requestId)
         clearTransferWatchdog(requestId)
         activeChannelRequestIds.remove(requestId)
+        openAudioStreams.remove(requestId)
+        watchdogTimedOutRequestIds.remove(requestId)
+        // Single funnel for every failure reason (empty file, metadata never arrived, write
+        // errors, duplicate rejection, idle timeout, ...) — the phone needs the real outcome so
+        // it stops believing a song landed just because it finished sending bytes. See
+        // notifyPhoneTransferOutcome's doc for why this is the source of truth now.
+        requestIdToSourceNode.remove(requestId)?.let { nodeId ->
+            notifyPhoneTransferOutcome(
+                targetNodeId = nodeId,
+                requestId = requestId,
+                songId = songId,
+                status = WearTransferProgress.STATUS_FAILED,
+                error = message,
+            )
+        }
     }
 
     private fun resolveTemporaryPlaybackStartPosition(
@@ -1044,7 +1209,25 @@ class WearTransferRepository @Inject constructor(
         transferWatchdogs[requestId] = scope.launch {
             delay(TRANSFER_IDLE_TIMEOUT_MS)
             if (_activeTransfers.value.containsKey(requestId)) {
-                handleTransferError(requestId, songId, "Transfer timed out")
+                val stream = openAudioStreams[requestId]
+                if (stream != null) {
+                    // A live audio stream is genuinely stuck: close it so the blocking
+                    // read() in onAudioChannelOpened unblocks with an IOException and routes
+                    // through that function's own catch block for cleanup — a single,
+                    // consistent path instead of this watchdog declaring failure on its own
+                    // while the read loop keeps running in the background, unaware anything
+                    // happened. That's what let a "failed" transfer keep going and finish
+                    // seconds later anyway, or worse, strip pendingMetadata out from under
+                    // the still-running loop and turn a slow-but-fine transfer into a real
+                    // failure ("Transfer metadata missing" from the loop's own metadata
+                    // resolution not finding what this watchdog had just cleared).
+                    watchdogTimedOutRequestIds.add(requestId)
+                    runCatching { stream.close() }
+                } else {
+                    // No audio stream open yet (still waiting on metadata/channel) — nothing
+                    // to interrupt, so this is still the right place to declare failure.
+                    handleTransferError(requestId, songId, "Transfer timed out")
+                }
             }
         }
     }

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
@@ -154,6 +154,12 @@ class WearTransferRepository @Inject constructor(
         private const val WATCHDOG_TOUCH_INTERVAL_MS = 1_500L
         private const val LOCAL_PROGRESS_UPDATE_INTERVAL_BYTES = 65_536L
         private const val CANCELLED_REQUEST_RETENTION_MS = 300_000L
+
+        /** Entries a later successful transfer of the same song makes obsolete. */
+        private val DISMISSABLE_STATUSES = setOf(
+            WearTransferProgress.STATUS_FAILED,
+            WearTransferProgress.STATUS_CANCELLED,
+        )
     }
 
     private data class PendingTemporaryPlaybackRequest(
@@ -855,7 +861,15 @@ class WearTransferRepository @Inject constructor(
                 currentArtworkPath = artworkPath,
             )
 
-            _activeTransfers.update { it - requestId }
+            // Drops this request's entry *and* any earlier failure left over for the same song:
+            // once the song is genuinely on the watch, a stale "Error en la transferencia" chip
+            // for it is just wrong — the retry that the user was told to make has succeeded.
+            _activeTransfers.update { map ->
+                map.filterNot { (entryRequestId, entry) ->
+                    entryRequestId == requestId ||
+                        (entry.songId == resolvedMetadata.songId && entry.status in DISMISSABLE_STATUSES)
+                }
+            }
             songToRequestId.remove(resolvedMetadata.songId)
             clearTransferWatchdog(requestId)
 
@@ -969,8 +983,14 @@ class WearTransferRepository @Inject constructor(
         songIds: Set<String>? = null,
     ) {
         val snapshotSongIds = songIds ?: localSongDao.getAllSongIds().first().toSet()
+        val snapshotPlaylistIds = runCatching { localPlaylistDao.getAllPlaylistIdsOnce() }
+            .onFailure { error -> Timber.tag(TAG).w(error, "Failed to read local playlist ids") }
+            .getOrDefault(emptyList())
         val payload = json.encodeToString(
-            WearLibraryState(songIds = snapshotSongIds.sorted())
+            WearLibraryState(
+                songIds = snapshotSongIds.sorted(),
+                playlistIds = snapshotPlaylistIds.sorted(),
+            )
         ).toByteArray(Charsets.UTF_8)
 
         runCatching {
@@ -1132,10 +1152,17 @@ class WearTransferRepository @Inject constructor(
 
     private suspend fun handleTransferError(requestId: String, songId: String, message: String) {
         Timber.tag(TAG).e("Transfer error: $message (requestId=$requestId, songId=$songId)")
+        // A failure chip with no title reads as "something went wrong, good luck" — the song's
+        // name is what makes it actionable, and it's still recoverable here even when the entry
+        // was created before any metadata arrived.
+        val resolvedTitle = pendingMetadata[requestId]?.title?.takeIf { it.isNotBlank() }
+            ?: songId.takeIf { it.isNotBlank() }
+                ?.let { runCatching { localSongDao.getSongById(it)?.title }.getOrNull() }
         _activeTransfers.update { map ->
             val current = map[requestId]
             if (current != null) {
                 map + (requestId to current.copy(
+                    songTitle = current.songTitle.ifBlank { resolvedTitle.orEmpty() },
                     status = WearTransferProgress.STATUS_FAILED,
                     error = message,
                 ))

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
@@ -671,6 +671,43 @@ class WearTransferRepository @Inject constructor(
                 return
             }
 
+            // The read loop exiting cleanly is not proof the whole file arrived: armTransferWatchdog
+            // interrupts a stuck transfer by closing this very stream, and a closed channel stream's
+            // blocking read() can return -1 instead of throwing — which walks straight out of the
+            // loop and down this path with a partial .part file. Committing that would rename a
+            // truncated song into the music dir, insert it into Room as playable, and report
+            // STATUS_COMPLETED to the phone, so the phone would mark it present on the watch and
+            // never retry it.
+            // Only short files are rejected, never long ones: fileSize comes from whatever source
+            // the phone opened and is 0 (unknown) for a content uri that won't report a length,
+            // so treating "more bytes than announced" as corruption would fail transfers that are
+            // actually fine. A file that stops short of its announced size is unambiguous.
+            val expectedSize = resolvedMetadata.fileSize
+            val isTruncated = if (expectedSize > 0L) {
+                actualSize < expectedSize
+            } else {
+                watchdogTimedOutRequestIds.contains(requestId)
+            }
+            if (isTruncated) {
+                tempFile.delete()
+                Timber.tag(TAG).w(
+                    "Incomplete transfer discarded: requestId=%s received=%d expected=%d",
+                    requestId,
+                    actualSize,
+                    expectedSize,
+                )
+                handleTransferError(
+                    requestId = requestId,
+                    songId = resolvedMetadata.songId,
+                    message = if (watchdogTimedOutRequestIds.contains(requestId)) {
+                        "Transfer timed out"
+                    } else {
+                        "Incomplete file received"
+                    },
+                )
+                return
+            }
+
             val extension = MimeTypeMap.getSingleton()
                 .getExtensionFromMimeType(resolvedMetadata.mimeType) ?: "mp3"
             if (resolvedMetadata.transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK) {

--- a/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistDao.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistDao.kt
@@ -1,0 +1,53 @@
+package com.theveloper.pixelplay.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO for locally stored playlist snapshots on the watch.
+ */
+@Dao
+interface LocalPlaylistDao {
+
+    /**
+     * Replaces the playlist row and its full song membership/order in one transaction, so a
+     * re-sync (e.g. after adding a song on the phone) always reflects the latest order rather
+     * than merging with stale cross-refs.
+     */
+    @Transaction
+    suspend fun upsertPlaylist(entity: LocalPlaylistEntity, songCrossRefs: List<LocalPlaylistSongCrossRef>) {
+        insertPlaylist(entity)
+        deleteSongsForPlaylist(entity.playlistId)
+        insertSongCrossRefs(songCrossRefs)
+    }
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylist(entity: LocalPlaylistEntity)
+
+    @Query("SELECT * FROM local_playlists WHERE playlistId = :playlistId")
+    suspend fun getPlaylistById(playlistId: String): LocalPlaylistEntity?
+
+    @Query("DELETE FROM local_playlist_songs WHERE playlistId = :playlistId")
+    suspend fun deleteSongsForPlaylist(playlistId: String)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSongCrossRefs(crossRefs: List<LocalPlaylistSongCrossRef>)
+
+    @Query("SELECT * FROM local_playlists ORDER BY updatedAt DESC")
+    fun observePlaylists(): Flow<List<LocalPlaylistEntity>>
+
+    @Query("SELECT * FROM local_playlist_songs WHERE playlistId = :playlistId ORDER BY position ASC")
+    fun observePlaylistSongs(playlistId: String): Flow<List<LocalPlaylistSongCrossRef>>
+
+    /**
+     * All playlist/song memberships across every playlist — used to map an in-flight transfer's
+     * songId back to the playlist(s) it belongs to (e.g. to show "receiving" state on a playlist
+     * card while one of its songs is still transferring).
+     */
+    @Query("SELECT * FROM local_playlist_songs")
+    fun observeAllPlaylistSongCrossRefs(): Flow<List<LocalPlaylistSongCrossRef>>
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistDao.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistDao.kt
@@ -31,6 +31,9 @@ interface LocalPlaylistDao {
     @Query("SELECT * FROM local_playlists WHERE playlistId = :playlistId")
     suspend fun getPlaylistById(playlistId: String): LocalPlaylistEntity?
 
+    @Query("SELECT playlistId FROM local_playlists")
+    suspend fun getAllPlaylistIdsOnce(): List<String>
+
     @Query("DELETE FROM local_playlist_songs WHERE playlistId = :playlistId")
     suspend fun deleteSongsForPlaylist(playlistId: String)
 

--- a/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistEntity.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistEntity.kt
@@ -1,0 +1,17 @@
+package com.theveloper.pixelplay.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity representing a playlist snapshot synced from the phone, so the watch can browse
+ * and play it offline. Membership and order live separately in [LocalPlaylistSongCrossRef] —
+ * this row only carries the playlist's own identity and timestamps.
+ */
+@Entity(tableName = "local_playlists")
+data class LocalPlaylistEntity(
+    @PrimaryKey val playlistId: String,
+    val name: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+)

--- a/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistSongCrossRef.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/local/LocalPlaylistSongCrossRef.kt
@@ -1,0 +1,30 @@
+package com.theveloper.pixelplay.data.local
+
+import androidx.room.Entity
+import androidx.room.Index
+
+/**
+ * Junction row recording that [songId] belongs to [playlistId] at [position]. Deliberately has
+ * no foreign key to `local_songs`: a playlist syncs its full membership/order up front, before
+ * the audio for every song has finished transferring (see `WearPlaylistSync`), so a cross-ref
+ * routinely points at a songId that doesn't have a matching [LocalSongEntity] row yet.
+ *
+ * [pendingTitle] is a best-effort display name from that same sync, used only while the song
+ * hasn't arrived — once [LocalSongEntity] exists for [songId], the UI reads the real title from
+ * there instead. Empty if the sync that created this row predates [pendingTitle] (an older phone
+ * build) or otherwise didn't include it; callers fall back to showing [songId] in that case.
+ */
+@Entity(
+    tableName = "local_playlist_songs",
+    primaryKeys = ["playlistId", "songId"],
+    indices = [
+        Index(value = ["playlistId", "position"]),
+        Index(value = ["songId"]),
+    ],
+)
+data class LocalPlaylistSongCrossRef(
+    val playlistId: String,
+    val songId: String,
+    val position: Int,
+    val pendingTitle: String = "",
+)

--- a/wear/src/main/java/com/theveloper/pixelplay/data/local/WearMusicDatabase.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/local/WearMusicDatabase.kt
@@ -9,9 +9,14 @@ import androidx.sqlite.db.SupportSQLiteDatabase
  * Room database for locally stored songs on the watch.
  * Tracks songs that have been transferred from the phone for offline playback.
  */
-@Database(entities = [LocalSongEntity::class], version = 5, exportSchema = false)
+@Database(
+    entities = [LocalSongEntity::class, LocalPlaylistEntity::class, LocalPlaylistSongCrossRef::class],
+    version = 7,
+    exportSchema = false,
+)
 abstract class WearMusicDatabase : RoomDatabase() {
     abstract fun localSongDao(): LocalSongDao
+    abstract fun localPlaylistDao(): LocalPlaylistDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -38,5 +43,45 @@ abstract class WearMusicDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE local_songs ADD COLUMN favoriteSyncPending INTEGER NOT NULL DEFAULT 0")
             }
         }
+
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS local_playlists (" +
+                        "playlistId TEXT NOT NULL PRIMARY KEY, " +
+                        "name TEXT NOT NULL, " +
+                        "createdAt INTEGER NOT NULL, " +
+                        "updatedAt INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS local_playlist_songs (" +
+                        "playlistId TEXT NOT NULL, " +
+                        "songId TEXT NOT NULL, " +
+                        "position INTEGER NOT NULL, " +
+                        "PRIMARY KEY(playlistId, songId))"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_local_playlist_songs_playlistId_position " +
+                        "ON local_playlist_songs(playlistId, position)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_local_playlist_songs_songId " +
+                        "ON local_playlist_songs(songId)"
+                )
+            }
+        }
+
+        val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE local_playlist_songs ADD COLUMN pendingTitle TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
+        /** Every migration this database has ever declared, in order — wire all of them, not just the newest. */
+        val ALL_MIGRATIONS = arrayOf(
+            MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7,
+        )
     }
 }

--- a/wear/src/main/java/com/theveloper/pixelplay/di/WearModule.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/di/WearModule.kt
@@ -1,14 +1,18 @@
 package com.theveloper.pixelplay.di
 
 import android.app.Application
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.room.Room
 import com.google.android.gms.wearable.ChannelClient
 import com.google.android.gms.wearable.DataClient
 import com.google.android.gms.wearable.MessageClient
 import com.google.android.gms.wearable.NodeClient
 import com.google.android.gms.wearable.Wearable
+import com.theveloper.pixelplay.data.local.LocalPlaylistDao
 import com.theveloper.pixelplay.data.local.LocalSongDao
 import com.theveloper.pixelplay.data.local.WearMusicDatabase
+import com.theveloper.pixelplay.data.wearDataStore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -46,10 +50,22 @@ object WearModule {
             application,
             WearMusicDatabase::class.java,
             "wear_music.db"
-        ).build()
+        )
+            .addMigrations(*WearMusicDatabase.ALL_MIGRATIONS)
+            .build()
 
     @Provides
     @Singleton
     fun provideLocalSongDao(database: WearMusicDatabase): LocalSongDao =
         database.localSongDao()
+
+    @Provides
+    @Singleton
+    fun provideLocalPlaylistDao(database: WearMusicDatabase): LocalPlaylistDao =
+        database.localPlaylistDao()
+
+    @Provides
+    @Singleton
+    fun provideDataStore(application: Application): DataStore<Preferences> =
+        application.wearDataStore
 }

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/WearMainActivity.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/WearMainActivity.kt
@@ -42,11 +42,14 @@ class WearMainActivity : FragmentActivity() {
             val albumArt by playerViewModel.albumArt.collectAsStateWithLifecycle()
             val paletteSeedArgb by playerViewModel.paletteSeedArgb.collectAsStateWithLifecycle()
             val themePalette by playerViewModel.themePalette.collectAsStateWithLifecycle()
+            val dynamicColorEnabled by playerViewModel.dynamicColorThemingEnabled
+                .collectAsStateWithLifecycle()
 
             WearPixelPlayTheme(
                 albumArt = albumArt,
                 seedColorArgb = paletteSeedArgb,
                 themePalette = themePalette,
+                dynamicColorEnabled = dynamicColorEnabled,
             ) {
                 WearNavigation()
             }

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/WearMainActivity.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/WearMainActivity.kt
@@ -3,8 +3,8 @@ package com.theveloper.pixelplay.presentation
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.collectAsState
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.ambient.AmbientLifecycleObserver
 import com.theveloper.pixelplay.data.WearLifecycleState
@@ -39,9 +39,9 @@ class WearMainActivity : FragmentActivity() {
 
         setContent {
             val playerViewModel: WearPlayerViewModel = hiltViewModel()
-            val albumArt by playerViewModel.albumArt.collectAsState()
-            val paletteSeedArgb by playerViewModel.paletteSeedArgb.collectAsState()
-            val themePalette by playerViewModel.themePalette.collectAsState()
+            val albumArt by playerViewModel.albumArt.collectAsStateWithLifecycle()
+            val paletteSeedArgb by playerViewModel.paletteSeedArgb.collectAsStateWithLifecycle()
+            val themePalette by playerViewModel.themePalette.collectAsStateWithLifecycle()
 
             WearPixelPlayTheme(
                 albumArt = albumArt,

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/WearNavigation.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/WearNavigation.kt
@@ -9,6 +9,8 @@ import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.theveloper.pixelplay.presentation.screens.BrowseScreen
 import com.theveloper.pixelplay.presentation.screens.DownloadsScreen
 import com.theveloper.pixelplay.presentation.screens.LibraryListScreen
+import com.theveloper.pixelplay.presentation.screens.LocalPlaylistDetailScreen
+import com.theveloper.pixelplay.presentation.screens.LocalPlaylistsScreen
 import com.theveloper.pixelplay.presentation.screens.MoreScreen
 import com.theveloper.pixelplay.presentation.screens.OutputScreen
 import com.theveloper.pixelplay.presentation.screens.PlayerScreen
@@ -39,6 +41,8 @@ object WearScreens {
     const val DOWNLOADS = "downloads"
     const val LIBRARY_LIST = "library_list/{browseType}/{title}"
     const val SONG_LIST = "song_list/{browseType}/{contextId}/{title}"
+    const val LOCAL_PLAYLISTS = "local_playlists"
+    const val LOCAL_PLAYLIST_DETAIL = "local_playlist_detail/{playlistId}/{title}"
 
     fun libraryListRoute(browseType: String, title: String): String {
         return "library_list/$browseType/${URLEncoder.encode(title, "UTF-8")}"
@@ -46,6 +50,10 @@ object WearScreens {
 
     fun songListRoute(browseType: String, contextId: String, title: String): String {
         return "song_list/$browseType/$contextId/${URLEncoder.encode(title, "UTF-8")}"
+    }
+
+    fun localPlaylistDetailRoute(playlistId: String, title: String): String {
+        return "local_playlist_detail/$playlistId/${URLEncoder.encode(title, "UTF-8")}"
     }
 }
 
@@ -67,6 +75,16 @@ fun WearNavigation() {
                     WearScreens.libraryListRoute(browseType, title)
                 )
             }
+        }
+    }
+    // Starting playback from deep in Downloads/Playlists is otherwise a lot of swipes-back to
+    // reach the transport controls — jump straight there instead, clearing everything in
+    // between so a swipe-back from Player lands on Player's own dismiss behavior, not back
+    // through the browse stack.
+    val navigateToPlayer: () -> Unit = {
+        navController.navigate(WearScreens.PLAYER) {
+            popUpTo(WearScreens.PLAYER) { inclusive = true }
+            launchSingleTop = true
         }
     }
 
@@ -138,7 +156,42 @@ fun WearNavigation() {
         }
 
         composable(WearScreens.DOWNLOADS) {
-            DownloadsScreen()
+            DownloadsScreen(
+                onPlaylistsClick = {
+                    navController.navigate(WearScreens.LOCAL_PLAYLISTS) {
+                        launchSingleTop = true
+                    }
+                },
+                onPlaybackStarted = navigateToPlayer,
+            )
+        }
+
+        composable(WearScreens.LOCAL_PLAYLISTS) {
+            LocalPlaylistsScreen(
+                onPlaylistClick = { playlistId, title ->
+                    navController.navigate(
+                        WearScreens.localPlaylistDetailRoute(playlistId, title)
+                    )
+                },
+            )
+        }
+
+        composable(
+            route = WearScreens.LOCAL_PLAYLIST_DETAIL,
+            arguments = listOf(
+                navArgument("playlistId") { type = NavType.StringType },
+                navArgument("title") { type = NavType.StringType },
+            ),
+        ) { backStackEntry ->
+            val playlistId = backStackEntry.arguments?.getString("playlistId") ?: ""
+            val title = URLDecoder.decode(
+                backStackEntry.arguments?.getString("title") ?: "", "UTF-8"
+            )
+            LocalPlaylistDetailScreen(
+                playlistId = playlistId,
+                title = title,
+                onPlaybackStarted = navigateToPlayer,
+            )
         }
 
         composable(WearScreens.BROWSE) {

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/components/PlayingEqIcon.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/components/PlayingEqIcon.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -16,6 +15,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.theveloper.pixelplay.data.WearLifecycleState
 import kotlinx.coroutines.isActive
 import kotlin.math.PI
@@ -36,8 +36,8 @@ fun PlayingEqIcon(
     val fullRotation = (2f * PI).toFloat()
     val phaseAnim = remember { Animatable(0f) }
     val wanderAnim = remember { Animatable(0f) }
-    val isInteractive by WearLifecycleState.isInteractive.collectAsState(
-        initial = WearLifecycleState.isInteractiveNow,
+    val isInteractive by WearLifecycleState.isInteractive.collectAsStateWithLifecycle(
+        initialValue = WearLifecycleState.isInteractiveNow,
     )
     val animate = isPlaying && isInteractive
 

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/DownloadsScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/DownloadsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.ErrorOutline
@@ -28,7 +29,6 @@ import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.core.content.ContextCompat
 import androidx.wear.compose.material.Chip
@@ -81,17 +82,19 @@ import kotlinx.coroutines.flow.collect
  */
 @Composable
 fun DownloadsScreen(
+    onPlaylistsClick: () -> Unit = {},
+    onPlaybackStarted: () -> Unit = {},
     viewModel: WearDownloadsViewModel = hiltViewModel(),
     playerViewModel: WearPlayerViewModel = hiltViewModel(),
 ) {
-    val localSongs by viewModel.localSongs.collectAsState()
-    val activeTransfers by viewModel.activeTransfers.collectAsState()
-    val deviceSongs by viewModel.deviceSongs.collectAsState()
-    val isDeviceLibraryLoading by viewModel.isDeviceLibraryLoading.collectAsState()
-    val deviceLibraryError by viewModel.deviceLibraryError.collectAsState()
-    val pendingPhonePlaybackSongId by viewModel.pendingPhonePlaybackSongId.collectAsState()
-    val playerState by playerViewModel.playerState.collectAsState()
-    val isPhoneConnected by playerViewModel.isPhoneConnected.collectAsState()
+    val localSongs by viewModel.localSongs.collectAsStateWithLifecycle()
+    val activeTransfers by viewModel.activeTransfers.collectAsStateWithLifecycle()
+    val deviceSongs by viewModel.deviceSongs.collectAsStateWithLifecycle()
+    val isDeviceLibraryLoading by viewModel.isDeviceLibraryLoading.collectAsStateWithLifecycle()
+    val deviceLibraryError by viewModel.deviceLibraryError.collectAsStateWithLifecycle()
+    val pendingPhonePlaybackSongId by viewModel.pendingPhonePlaybackSongId.collectAsStateWithLifecycle()
+    val playerState by playerViewModel.playerState.collectAsStateWithLifecycle()
+    val isPhoneConnected by playerViewModel.isPhoneConnected.collectAsStateWithLifecycle()
     val palette = LocalWearPalette.current
     val watchLibraryTitleFont = rememberWatchLibraryTitleFont()
     val columnState = rememberResponsiveColumnState()
@@ -177,6 +180,33 @@ fun DownloadsScreen(
                     fontWeight = FontWeight(780),
                     color = palette.textPrimary,
                     textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 4.dp),
+                )
+            }
+
+            item {
+                Chip(
+                    label = {
+                        Text(
+                            text = stringResource(R.string.wear_local_playlists_entry),
+                            color = palette.textPrimary,
+                        )
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.QueueMusic,
+                            contentDescription = null,
+                            tint = palette.textSecondary,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                    onClick = onPlaylistsClick,
+                    colors = ChipDefaults.chipColors(
+                        backgroundColor = surfaceContainer,
+                        contentColor = palette.chipContent,
+                    ),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 4.dp),
@@ -298,12 +328,12 @@ fun DownloadsScreen(
                         icon = {
                             Icon(
                                 imageVector = Icons.Rounded.ErrorOutline,
-                                contentDescription = null,
+                                contentDescription = stringResource(R.string.wear_transfer_dismiss_hint),
                                 tint = palette.textError,
                                 modifier = Modifier.size(18.dp),
                             )
                         },
-                        onClick = {},
+                        onClick = { viewModel.dismissTransfer(transfer.requestId) },
                         colors = ChipDefaults.chipColors(
                             backgroundColor = elevatedSurfaceContainer,
                             contentColor = palette.chipContent,
@@ -555,10 +585,12 @@ fun DownloadsScreen(
                 onPlayOnWatch = {
                     viewModel.playLocalSong(menuSong.songId)
                     selectedLocalSongForMenu = null
+                    onPlaybackStarted()
                 },
                 onPlayOnPhone = {
                     viewModel.playSongOnPhone(menuSong.songId)
                     selectedLocalSongForMenu = null
+                    onPlaybackStarted()
                 },
                 onDeleteFromWatch = {
                     selectedLocalSongForMenu = null

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryListScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryListScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,6 +20,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -59,7 +59,7 @@ fun LibraryListScreen(
     onItemClick: (item: WearLibraryItem, subBrowseType: String, itemTitle: String) -> Unit,
     viewModel: WearBrowseViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val palette = LocalWearPalette.current
     val subscreenTitleFont = rememberBrowseSubscreenTitleFont()
 

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/LocalPlaylistDetailScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/LocalPlaylistDetailScreen.kt
@@ -1,0 +1,273 @@
+package com.theveloper.pixelplay.presentation.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.presentation.components.AlwaysOnScalingPositionIndicator
+import com.theveloper.pixelplay.presentation.components.PlayingEqIcon
+import com.theveloper.pixelplay.presentation.components.WearTopTimeText
+import com.theveloper.pixelplay.presentation.theme.LocalWearPalette
+import com.theveloper.pixelplay.presentation.theme.screenBackgroundColor
+import com.theveloper.pixelplay.presentation.theme.surfaceContainerColor
+import com.theveloper.pixelplay.presentation.theme.surfaceContainerHighColor
+import com.theveloper.pixelplay.presentation.viewmodel.WearLocalPlaylistSongItem
+import com.theveloper.pixelplay.presentation.viewmodel.WearLocalPlaylistViewModel
+import com.theveloper.pixelplay.presentation.viewmodel.WearPlayerViewModel
+
+/**
+ * Songs in a phone playlist synced locally on the watch. Songs still awaiting transfer show as
+ * disabled with a "waiting to transfer" label rather than being hidden — the list order and count
+ * matches the phone immediately, only playability lags behind.
+ */
+@Composable
+fun LocalPlaylistDetailScreen(
+    playlistId: String,
+    title: String,
+    onPlaybackStarted: () -> Unit = {},
+    viewModel: WearLocalPlaylistViewModel = hiltViewModel(),
+    playerViewModel: WearPlayerViewModel = hiltViewModel(),
+) {
+    val playlistDetails by viewModel.playlistDetails.collectAsStateWithLifecycle()
+    val songs by viewModel.playlistSongs.collectAsStateWithLifecycle()
+    val playerState by playerViewModel.playerState.collectAsStateWithLifecycle()
+    val palette = LocalWearPalette.current
+    val columnState = rememberResponsiveColumnState()
+    val background = palette.screenBackgroundColor()
+    val displayTitle = playlistDetails?.name ?: title
+    val availableCount = songs.count { it.isAvailable }
+
+    LaunchedEffect(playlistId) {
+        viewModel.loadPlaylist(playlistId)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(background),
+    ) {
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            columnState = columnState,
+        ) {
+            item { Spacer(modifier = Modifier.height(18.dp)) }
+
+            item {
+                Text(
+                    text = displayTitle,
+                    style = MaterialTheme.typography.title2,
+                    fontWeight = FontWeight(760),
+                    color = palette.textPrimary,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 2.dp),
+                )
+            }
+
+            if (songs.isNotEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(
+                            R.string.wear_playlist_pending_songs,
+                            availableCount,
+                            songs.size,
+                        ),
+                        style = MaterialTheme.typography.caption2,
+                        color = palette.textSecondary.copy(alpha = 0.82f),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 6.dp),
+                    )
+                }
+
+                item {
+                    val playAllEnabled = availableCount > 0
+                    val playAllContentColor = if (playAllEnabled) {
+                        palette.textPrimary
+                    } else {
+                        palette.textSecondary.copy(alpha = 0.72f)
+                    }
+                    Chip(
+                        label = { Text(text = stringResource(R.string.wear_play_all), color = playAllContentColor) },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Rounded.PlayArrow,
+                                contentDescription = null,
+                                tint = playAllContentColor,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        },
+                        onClick = { viewModel.playAll(); onPlaybackStarted() },
+                        enabled = playAllEnabled,
+                        colors = ChipDefaults.chipColors(
+                            backgroundColor = if (playAllEnabled) {
+                                palette.shuffleActive.copy(alpha = 0.38f)
+                            } else {
+                                palette.surfaceContainerHighColor()
+                            },
+                            contentColor = palette.chipContent,
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 4.dp),
+                    )
+                }
+            }
+
+            if (songs.isEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(R.string.wear_playlist_empty),
+                        style = MaterialTheme.typography.body2,
+                        color = palette.textSecondary.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                    )
+                }
+            } else {
+                items(items = songs, key = { it.songId }) { item ->
+                    val isCurrentSong = item.song != null &&
+                        item.songId == playerState.songId &&
+                        playerState.songId.isNotBlank()
+                    val isPlayingSong = isCurrentSong && playerState.isPlaying
+                    LocalPlaylistSongChip(
+                        item = item,
+                        isCurrentSong = isCurrentSong,
+                        isPlayingSong = isPlayingSong,
+                        onClick = {
+                            if (item.isAvailable) {
+                                viewModel.playFrom(item.songId)
+                                onPlaybackStarted()
+                            }
+                        },
+                    )
+                }
+            }
+        }
+
+        AlwaysOnScalingPositionIndicator(
+            listState = columnState.state,
+            modifier = Modifier.align(Alignment.CenterEnd),
+            color = palette.textPrimary,
+        )
+
+        WearTopTimeText(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .zIndex(5f),
+            color = palette.textPrimary,
+        )
+    }
+}
+
+@Composable
+private fun LocalPlaylistSongChip(
+    item: WearLocalPlaylistSongItem,
+    isCurrentSong: Boolean,
+    isPlayingSong: Boolean,
+    onClick: () -> Unit,
+) {
+    val palette = LocalWearPalette.current
+    val song = item.song
+    val title = item.displayTitle
+    val containerColor = if (isCurrentSong) palette.surfaceContainerHighColor() else palette.surfaceContainerColor()
+    val contentAlpha = if (item.isAvailable) 1f else 0.55f
+
+    Chip(
+        label = {
+            Text(
+                text = title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = palette.textPrimary.copy(alpha = contentAlpha),
+            )
+        },
+        secondaryLabel = when {
+            !item.isAvailable -> {
+                {
+                    Text(
+                        text = stringResource(R.string.wear_song_pending_transfer),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = palette.textSecondary.copy(alpha = 0.72f),
+                    )
+                }
+            }
+            !song?.artist.isNullOrEmpty() -> {
+                {
+                    Text(
+                        text = song.artist.orEmpty(),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = palette.textSecondary.copy(alpha = 0.78f),
+                    )
+                }
+            }
+            else -> null
+        },
+        icon = {
+            when {
+                isCurrentSong -> PlayingEqIcon(
+                    color = if (isPlayingSong) palette.shuffleActive else palette.textSecondary,
+                    isPlaying = isPlayingSong,
+                    modifier = Modifier.size(18.dp),
+                )
+                !item.isAvailable -> CircularProgressIndicator(
+                    indicatorColor = palette.textSecondary.copy(alpha = 0.6f),
+                    trackColor = palette.surfaceContainerColor(),
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                )
+                else -> Icon(
+                    imageVector = Icons.Rounded.MusicNote,
+                    contentDescription = null,
+                    tint = palette.textSecondary,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        },
+        onClick = onClick,
+        enabled = item.isAvailable,
+        colors = ChipDefaults.chipColors(
+            backgroundColor = containerColor,
+            contentColor = palette.chipContent,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    )
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/LocalPlaylistsScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/LocalPlaylistsScreen.kt
@@ -1,0 +1,179 @@
+package com.theveloper.pixelplay.presentation.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.data.local.LocalPlaylistEntity
+import com.theveloper.pixelplay.presentation.components.AlwaysOnScalingPositionIndicator
+import com.theveloper.pixelplay.presentation.components.WearTopTimeText
+import com.theveloper.pixelplay.presentation.theme.LocalWearPalette
+import com.theveloper.pixelplay.presentation.theme.screenBackgroundColor
+import com.theveloper.pixelplay.presentation.theme.surfaceContainerColor
+import com.theveloper.pixelplay.presentation.theme.surfaceContainerHighColor
+import com.theveloper.pixelplay.presentation.viewmodel.WearLocalPlaylistViewModel
+
+/**
+ * Playlists synced from the phone, stored locally on the watch. Tapping one opens
+ * [LocalPlaylistDetailScreen] regardless of whether every song has finished transferring yet —
+ * the playlist's membership/order arrives before its audio (see `WearPlaylistSync`), so the list
+ * itself is meaningful immediately.
+ */
+@Composable
+fun LocalPlaylistsScreen(
+    onPlaylistClick: (playlistId: String, title: String) -> Unit,
+    viewModel: WearLocalPlaylistViewModel = hiltViewModel(),
+) {
+    val playlists by viewModel.playlists.collectAsStateWithLifecycle()
+    val playlistIdsReceiving by viewModel.playlistIdsReceiving.collectAsStateWithLifecycle()
+    val palette = LocalWearPalette.current
+    val columnState = rememberResponsiveColumnState()
+    val background = palette.screenBackgroundColor()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(background),
+    ) {
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            columnState = columnState,
+        ) {
+            item { Spacer(modifier = Modifier.height(18.dp)) }
+
+            item {
+                Text(
+                    text = stringResource(R.string.wear_playlists_title),
+                    style = MaterialTheme.typography.title2,
+                    fontWeight = FontWeight(760),
+                    color = palette.textPrimary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 4.dp),
+                )
+            }
+
+            if (playlists.isEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(R.string.wear_no_local_playlists),
+                        style = MaterialTheme.typography.body2,
+                        color = palette.textSecondary.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                    )
+                }
+            } else {
+                items(items = playlists, key = { it.playlistId }) { playlist ->
+                    LocalPlaylistChip(
+                        playlist = playlist,
+                        isReceiving = playlistIdsReceiving.contains(playlist.playlistId),
+                        onClick = { onPlaylistClick(playlist.playlistId, playlist.name) },
+                    )
+                }
+            }
+        }
+
+        AlwaysOnScalingPositionIndicator(
+            listState = columnState.state,
+            modifier = Modifier.align(Alignment.CenterEnd),
+            color = palette.textPrimary,
+        )
+
+        WearTopTimeText(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .zIndex(5f),
+            color = palette.textPrimary,
+        )
+    }
+}
+
+@Composable
+private fun LocalPlaylistChip(
+    playlist: LocalPlaylistEntity,
+    isReceiving: Boolean,
+    onClick: () -> Unit,
+) {
+    val palette = LocalWearPalette.current
+    Chip(
+        label = {
+            Text(
+                text = playlist.name,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = palette.textPrimary,
+            )
+        },
+        secondaryLabel = if (isReceiving) {
+            {
+                Text(
+                    text = stringResource(R.string.wear_playlist_receiving),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = palette.shuffleActive.copy(alpha = 0.90f),
+                )
+            }
+        } else {
+            null
+        },
+        icon = {
+            if (isReceiving) {
+                CircularProgressIndicator(
+                    indicatorColor = palette.shuffleActive,
+                    trackColor = palette.surfaceContainerColor(),
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.QueueMusic,
+                    contentDescription = null,
+                    tint = palette.textSecondary,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        },
+        onClick = onClick,
+        colors = ChipDefaults.chipColors(
+            backgroundColor = if (isReceiving) {
+                palette.surfaceContainerHighColor()
+            } else {
+                palette.surfaceContainerColor()
+            },
+            contentColor = palette.chipContent,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    )
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/MoreScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/MoreScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -72,13 +72,13 @@ fun MoreScreen(
     val palette = LocalWearPalette.current
     val columnState = rememberResponsiveColumnState()
 
-    val playerState by playerViewModel.playerState.collectAsState()
-    val isPhoneConnected by playerViewModel.isPhoneConnected.collectAsState()
-    val isWatchOutputSelected by playerViewModel.isWatchOutputSelected.collectAsState()
-    val canCurrentSongBeFavorited by playerViewModel.canCurrentSongBeFavorited.collectAsState()
-    val queueState by browseViewModel.uiState.collectAsState()
-    val downloadedSongIds by downloadsViewModel.downloadedSongIds.collectAsState()
-    val activeTransfers by downloadsViewModel.activeTransfers.collectAsState()
+    val playerState by playerViewModel.playerState.collectAsStateWithLifecycle()
+    val isPhoneConnected by playerViewModel.isPhoneConnected.collectAsStateWithLifecycle()
+    val isWatchOutputSelected by playerViewModel.isWatchOutputSelected.collectAsStateWithLifecycle()
+    val canCurrentSongBeFavorited by playerViewModel.canCurrentSongBeFavorited.collectAsStateWithLifecycle()
+    val queueState by browseViewModel.uiState.collectAsStateWithLifecycle()
+    val downloadedSongIds by downloadsViewModel.downloadedSongIds.collectAsStateWithLifecycle()
+    val activeTransfers by downloadsViewModel.activeTransfers.collectAsStateWithLifecycle()
 
     LaunchedEffect(isPhoneConnected, isWatchOutputSelected) {
         if (isPhoneConnected && !isWatchOutputSelected) {

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/OutputScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/OutputScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.rounded.Watch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import android.content.Context
 import androidx.compose.ui.Alignment
@@ -27,6 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -55,13 +55,13 @@ import kotlinx.coroutines.delay
 fun OutputScreen(
     viewModel: WearPlayerViewModel = hiltViewModel(),
 ) {
-    val outputTarget by viewModel.outputTarget.collectAsState()
-    val isPhoneConnected by viewModel.isPhoneConnected.collectAsState()
-    val canCurrentSongPlayOnWatch by viewModel.canCurrentSongPlayOnWatch.collectAsState()
-    val playerState by viewModel.playerState.collectAsState()
-    val phoneVolumeState by viewModel.phoneVolumeState.collectAsState()
-    val watchAudioRoutes by viewModel.watchAudioRoutes.collectAsState()
-    val watchVolumeState by viewModel.watchVolumeState.collectAsState()
+    val outputTarget by viewModel.outputTarget.collectAsStateWithLifecycle()
+    val isPhoneConnected by viewModel.isPhoneConnected.collectAsStateWithLifecycle()
+    val canCurrentSongPlayOnWatch by viewModel.canCurrentSongPlayOnWatch.collectAsStateWithLifecycle()
+    val playerState by viewModel.playerState.collectAsStateWithLifecycle()
+    val phoneVolumeState by viewModel.phoneVolumeState.collectAsStateWithLifecycle()
+    val watchAudioRoutes by viewModel.watchAudioRoutes.collectAsStateWithLifecycle()
+    val watchVolumeState by viewModel.watchVolumeState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val palette = LocalWearPalette.current
     val columnState = rememberResponsiveColumnState()

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/PlayerScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/PlayerScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -98,6 +97,7 @@ import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.pager.HorizontalPager
 import androidx.wear.compose.foundation.pager.rememberPagerState
@@ -149,12 +149,13 @@ fun PlayerScreen(
     onQueueClick: () -> Unit = {},
     viewModel: WearPlayerViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.playerState.collectAsState()
-    val isPhoneConnected by viewModel.isPhoneConnected.collectAsState()
-    val isWatchOutputSelected by viewModel.isWatchOutputSelected.collectAsState()
-    val activeOutputRouteType by viewModel.activeOutputRouteType.collectAsState()
-    val activeVolumeState by viewModel.activeVolumeState.collectAsState()
-    val albumArt by viewModel.albumArt.collectAsState()
+    val state by viewModel.playerState.collectAsStateWithLifecycle()
+    val isPhoneConnected by viewModel.isPhoneConnected.collectAsStateWithLifecycle()
+    val isWatchOutputSelected by viewModel.isWatchOutputSelected.collectAsStateWithLifecycle()
+    val activeOutputRouteType by viewModel.activeOutputRouteType.collectAsStateWithLifecycle()
+    val activeVolumeState by viewModel.activeVolumeState.collectAsStateWithLifecycle()
+    val albumArt by viewModel.albumArt.collectAsStateWithLifecycle()
+    val showPlayButtonAnimation by viewModel.showPlayButtonAnimation.collectAsStateWithLifecycle()
 
     PlayerContent(
         state = state,
@@ -162,6 +163,7 @@ fun PlayerScreen(
         isPhoneConnected = isPhoneConnected,
         isWatchOutputSelected = isWatchOutputSelected,
         activeVolumeState = activeVolumeState,
+        showPlayButtonAnimation = showPlayButtonAnimation,
         onTogglePlayPause = viewModel::togglePlayPause,
         onNext = viewModel::next,
         onPrevious = viewModel::previous,
@@ -182,6 +184,7 @@ private fun PlayerContent(
     isPhoneConnected: Boolean,
     isWatchOutputSelected: Boolean = false,
     activeVolumeState: WearVolumeState,
+    showPlayButtonAnimation: Boolean = true,
     onTogglePlayPause: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
@@ -194,7 +197,7 @@ private fun PlayerContent(
     onQueueClick: () -> Unit,
 ) {
     val palette = LocalWearPalette.current
-    val isAmbient by WearLifecycleState.isAmbient.collectAsState()
+    val isAmbient by WearLifecycleState.isAmbient.collectAsStateWithLifecycle()
     // Memoize: radialGradient allocates Shader inputs on every call. PlayerContent
     // recomposes whenever the play-button ring animation ticks, so without this
     // we'd churn the GC for nothing.
@@ -272,6 +275,7 @@ private fun PlayerContent(
                         isPhoneConnected = isPhoneConnected,
                         isWatchOutputSelected = isWatchOutputSelected,
                         activeVolumeState = activeVolumeState,
+                        showPlayButtonAnimation = showPlayButtonAnimation,
                         onTogglePlayPause = onTogglePlayPause,
                         onNext = onNext,
                         onPrevious = onPrevious,
@@ -323,6 +327,7 @@ private fun PlayerMainPageHost(
     isPhoneConnected: Boolean,
     isWatchOutputSelected: Boolean,
     activeVolumeState: WearVolumeState,
+    showPlayButtonAnimation: Boolean,
     onTogglePlayPause: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
@@ -390,6 +395,7 @@ private fun PlayerMainPageHost(
                 isWatchOutputSelected = isWatchOutputSelected,
                 isAmbient = isAmbient,
                 activeVolumeState = activeVolumeState,
+                showPlayButtonAnimation = showPlayButtonAnimation,
                 onTogglePlayPause = onTogglePlayPause,
                 onNext = onNext,
                 onPrevious = onPrevious,
@@ -1052,6 +1058,7 @@ private fun MainPlayerPage(
     isWatchOutputSelected: Boolean = false,
     isAmbient: Boolean,
     activeVolumeState: WearVolumeState,
+    showPlayButtonAnimation: Boolean = true,
     onTogglePlayPause: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
@@ -1194,6 +1201,7 @@ private fun MainPlayerPage(
                     enabled = if (isWatchOutputSelected) !state.isEmpty else isPhoneConnected,
                     outlined = isAmbient,
                     trackProgress = trackProgress,
+                    showPlayButtonAnimation = showPlayButtonAnimation,
                     onTogglePlayPause = onTogglePlayPause,
                     onNext = onNext,
                     onPrevious = onPrevious,
@@ -1251,21 +1259,32 @@ private fun MainPlayerPage(
 private fun rememberLivePositionMs(state: WearPlayerState): androidx.compose.runtime.State<Long> {
     val safeDuration = state.totalDurationMs.coerceAtLeast(0L)
     val safeAnchorPosition = state.currentPositionMs.coerceIn(0L, safeDuration)
+    // WearLifecycleState's own contract: "position-update jobs... should gate on isInteractive
+    // so they pause as soon as the activity moves to the background or the watch enters ambient
+    // mode" — this loop wasn't wired to it. Ticking every 250ms recomposes this composable (and
+    // the progress ring/animation reading its value) whether or not the screen is actually being
+    // refreshed at that rate, competing with audio decode for CPU. `livePositionFromAnchor`
+    // computes from elapsed real time regardless, so freezing the display between ticks loses
+    // nothing: the moment isInteractive flips back on, the position snaps to the correct value.
+    val isInteractive by WearLifecycleState.isInteractive.collectAsStateWithLifecycle(
+        initialValue = WearLifecycleState.isInteractiveNow,
+    )
     val positionKey = remember(
         state.songId,
         safeAnchorPosition,
         safeDuration,
         state.isPlaying,
         state.positionUpdatedElapsedRealtimeMs,
+        isInteractive,
     ) {
-        "${state.songId}|$safeAnchorPosition|$safeDuration|${state.isPlaying}|${state.positionUpdatedElapsedRealtimeMs}"
+        "${state.songId}|$safeAnchorPosition|$safeDuration|${state.isPlaying}|${state.positionUpdatedElapsedRealtimeMs}|$isInteractive"
     }
     return produceState(
         initialValue = state.livePositionFromAnchor(safeAnchorPosition, safeDuration),
         key1 = positionKey,
     ) {
         value = state.livePositionFromAnchor(safeAnchorPosition, safeDuration)
-        if (!state.isPlaying || safeDuration <= 0L) {
+        if (!state.isPlaying || safeDuration <= 0L || !isInteractive) {
             return@produceState
         }
 
@@ -1485,6 +1504,13 @@ private fun rememberActiveLyricLineIndex(
 ): androidx.compose.runtime.State<Int> {
     val safeDuration = state.totalDurationMs.coerceAtLeast(0L)
     val safeAnchorPosition = state.currentPositionMs.coerceIn(0L, safeDuration)
+    // Same reasoning as rememberLivePositionMs: this page sits right next to the main player
+    // page in the HorizontalPager (beyondViewportPageCount = 1), so it can stay composed —
+    // and this loop ticking — while the user is looking at the main page instead. Gate it on
+    // WearLifecycleState.isInteractive for the same reason its own contract asks for.
+    val isInteractive by WearLifecycleState.isInteractive.collectAsStateWithLifecycle(
+        initialValue = WearLifecycleState.isInteractiveNow,
+    )
     val positionKey = remember(
         state.songId,
         safeAnchorPosition,
@@ -1492,8 +1518,9 @@ private fun rememberActiveLyricLineIndex(
         state.isPlaying,
         state.positionUpdatedElapsedRealtimeMs,
         lines,
+        isInteractive,
     ) {
-        "${state.songId}|$safeAnchorPosition|$safeDuration|${state.isPlaying}|${state.positionUpdatedElapsedRealtimeMs}|${lines.size}|${lines.firstOrNull()?.timeMs}|${lines.lastOrNull()?.timeMs}"
+        "${state.songId}|$safeAnchorPosition|$safeDuration|${state.isPlaying}|${state.positionUpdatedElapsedRealtimeMs}|${lines.size}|${lines.firstOrNull()?.timeMs}|${lines.lastOrNull()?.timeMs}|$isInteractive"
     }
 
     return produceState(
@@ -1507,9 +1534,15 @@ private fun rememberActiveLyricLineIndex(
             return@produceState
         }
 
+        val livePositionMs = state.livePositionFromAnchor(safeAnchorPosition, safeDuration)
+        value = lines.activeLyricLineIndex(livePositionMs)
+        if (!isInteractive) {
+            return@produceState
+        }
+
         while (true) {
-            val livePositionMs = state.livePositionFromAnchor(safeAnchorPosition, safeDuration)
-            val currentIndex = lines.activeLyricLineIndex(livePositionMs)
+            val currentLivePositionMs = state.livePositionFromAnchor(safeAnchorPosition, safeDuration)
+            val currentIndex = lines.activeLyricLineIndex(currentLivePositionMs)
             value = currentIndex
 
             if (!state.isPlaying || safeDuration <= 0L) {
@@ -1518,7 +1551,7 @@ private fun rememberActiveLyricLineIndex(
 
             val nextLineTimeMs = lines.getOrNull(currentIndex + 1)?.timeMs?.toLong()
                 ?: return@produceState
-            val delayUntilNextLine = (nextLineTimeMs - livePositionMs)
+            val delayUntilNextLine = (nextLineTimeMs - currentLivePositionMs)
                 .coerceIn(80L, 60_000L)
             delay(delayUntilNextLine)
         }
@@ -1633,6 +1666,7 @@ private fun MainControlsRow(
     enabled: Boolean,
     outlined: Boolean,
     trackProgress: Float,
+    showPlayButtonAnimation: Boolean = true,
     onTogglePlayPause: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
@@ -1661,6 +1695,7 @@ private fun MainControlsRow(
             enabled = enabled && !isEmpty,
             outlined = outlined,
             trackProgress = trackProgress,
+            showAnimation = showPlayButtonAnimation,
             onClick = onTogglePlayPause,
         )
 
@@ -1737,6 +1772,7 @@ private fun CenterPlayButton(
     outlined: Boolean,
     trackProgress: Float,
     onClick: () -> Unit,
+    showAnimation: Boolean = true,
 ) {
     val palette = LocalWearPalette.current
 
@@ -1746,11 +1782,14 @@ private fun CenterPlayButton(
         label = "playStarCurve",
     )
     val rotation = remember { Animatable(0f) }
-    val isInteractive by WearLifecycleState.isInteractive.collectAsState(
-        initial = WearLifecycleState.isInteractiveNow,
+    val isInteractive by WearLifecycleState.isInteractive.collectAsStateWithLifecycle(
+        initialValue = WearLifecycleState.isInteractiveNow,
     )
-    LaunchedEffect(isPlaying, isInteractive) {
-        if (!isPlaying || !isInteractive) {
+    // showAnimation off is treated exactly like "not interactive": settle back to 0° and stop —
+    // the ring itself still draws (and still reflects trackProgress), it just stops continuously
+    // rebuilding its 320-point path every animation frame while spinning.
+    LaunchedEffect(isPlaying, isInteractive, showAnimation) {
+        if (!isPlaying || !isInteractive || !showAnimation) {
             val normalizedRotation = ((rotation.value % 360f) + 360f) % 360f
             rotation.snapTo(normalizedRotation)
             rotation.animateTo(

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/QueueScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/QueueScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,6 +31,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -70,13 +70,13 @@ fun QueueScreen(
     browseViewModel: WearBrowseViewModel = hiltViewModel(),
 ) {
     val palette = LocalWearPalette.current
-    val playerState by viewModel.playerState.collectAsState()
-    val localQueueState by viewModel.localQueueState.collectAsState()
-    val isLocalPlaybackActive by viewModel.isLocalPlaybackActive.collectAsState()
-    val uiState by browseViewModel.uiState.collectAsState()
-    val isPhoneConnected by viewModel.isPhoneConnected.collectAsState()
-    val isWatchOutputSelected by viewModel.isWatchOutputSelected.collectAsState()
-    val timerState by viewModel.sleepTimerUiState.collectAsState()
+    val playerState by viewModel.playerState.collectAsStateWithLifecycle()
+    val localQueueState by viewModel.localQueueState.collectAsStateWithLifecycle()
+    val isLocalPlaybackActive by viewModel.isLocalPlaybackActive.collectAsStateWithLifecycle()
+    val uiState by browseViewModel.uiState.collectAsStateWithLifecycle()
+    val isPhoneConnected by viewModel.isPhoneConnected.collectAsStateWithLifecycle()
+    val isWatchOutputSelected by viewModel.isWatchOutputSelected.collectAsStateWithLifecycle()
+    val timerState by viewModel.sleepTimerUiState.collectAsStateWithLifecycle()
 
     val showingLocalQueue = isWatchOutputSelected
     val remoteControlsEnabled = isPhoneConnected && !isWatchOutputSelected

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/SongListScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/SongListScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +28,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -80,10 +80,10 @@ fun SongListScreen(
     downloadsViewModel: WearDownloadsViewModel = hiltViewModel(),
     playerViewModel: WearPlayerViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val downloadedIds by downloadsViewModel.downloadedSongIds.collectAsState()
-    val activeTransfers by downloadsViewModel.activeTransfers.collectAsState()
-    val playerState by playerViewModel.playerState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val downloadedIds by downloadsViewModel.downloadedSongIds.collectAsStateWithLifecycle()
+    val activeTransfers by downloadsViewModel.activeTransfers.collectAsStateWithLifecycle()
+    val playerState by playerViewModel.playerState.collectAsStateWithLifecycle()
     val palette = LocalWearPalette.current
     val subscreenTitleFont = rememberBrowseSubscreenTitleFont()
     var selectedSongForMenu by remember { mutableStateOf<WearLibraryItem?>(null) }

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/TimerScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/TimerScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,6 +22,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -52,9 +52,9 @@ fun TimerScreen(
 ) {
     val context = LocalContext.current
     val palette = LocalWearPalette.current
-    val timerState by viewModel.sleepTimerUiState.collectAsState()
-    val isPhoneConnected by viewModel.isPhoneConnected.collectAsState()
-    val isWatchOutputSelected by viewModel.isWatchOutputSelected.collectAsState()
+    val timerState by viewModel.sleepTimerUiState.collectAsStateWithLifecycle()
+    val isPhoneConnected by viewModel.isPhoneConnected.collectAsStateWithLifecycle()
+    val isWatchOutputSelected by viewModel.isWatchOutputSelected.collectAsStateWithLifecycle()
     val enabled = isPhoneConnected && !isWatchOutputSelected
     val columnState = rememberResponsiveColumnState()
 

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/VolumeScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/VolumeScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.rounded.Remove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -41,6 +40,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.requestFocusOnHierarchyActive
@@ -65,9 +65,9 @@ fun VolumeScreen(
     viewModel: WearPlayerViewModel = hiltViewModel(),
 ) {
     val palette = LocalWearPalette.current
-    val volumeState by viewModel.activeVolumeState.collectAsState()
-    val volumePercent by viewModel.activeVolumePercent.collectAsState()
-    val activeDeviceName by viewModel.activeVolumeDeviceName.collectAsState()
+    val volumeState by viewModel.activeVolumeState.collectAsStateWithLifecycle()
+    val volumePercent by viewModel.activeVolumePercent.collectAsStateWithLifecycle()
+    val activeDeviceName by viewModel.activeVolumeDeviceName.collectAsStateWithLifecycle()
 
     // Enable MediaRouter discovery while this screen is visible so the
     // route-callback path in WearVolumeRepository pushes updates reactively.

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/theme/WearTheme.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/theme/WearTheme.kt
@@ -98,8 +98,13 @@ fun WearPixelPlayTheme(
     val palette = remember(themePalette, albumArt, seedColorArgb) {
         when {
             themePalette != null -> themePalette.toWearPalette()
-            albumArt != null -> buildPaletteFromAlbumArt(albumArt)
+            // Prefer the seed over re-deriving one from the full bitmap: WearLocalPlayerRepository
+            // already extracts this cheaply off the main thread (small downsampled bitmap,
+            // recycled after use). Falling through to buildPaletteFromAlbumArt here would redo
+            // that work on the main thread against the full-size bitmap (~576 getPixel() calls)
+            // for no benefit, every time albumArt is present alongside a seed.
             seedColorArgb != null -> buildPaletteFromSeedColor(Color(seedColorArgb))
+            albumArt != null -> buildPaletteFromAlbumArt(albumArt)
             else -> DefaultWearPalette
         }
     }

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/theme/WearTheme.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/theme/WearTheme.kt
@@ -93,9 +93,10 @@ fun WearPixelPlayTheme(
     albumArt: Bitmap? = null,
     seedColorArgb: Int? = null,
     themePalette: WearThemePalette? = null,
+    dynamicColorEnabled: Boolean = true,
     content: @Composable () -> Unit,
 ) {
-    val palette = remember(themePalette, albumArt, seedColorArgb) {
+    val palette = remember(themePalette, albumArt, seedColorArgb, dynamicColorEnabled) {
         when {
             themePalette != null -> themePalette.toWearPalette()
             // Prefer the seed over re-deriving one from the full bitmap: WearLocalPlayerRepository
@@ -104,7 +105,11 @@ fun WearPixelPlayTheme(
             // that work on the main thread against the full-size bitmap (~576 getPixel() calls)
             // for no benefit, every time albumArt is present alongside a seed.
             seedColorArgb != null -> buildPaletteFromSeedColor(Color(seedColorArgb))
-            albumArt != null -> buildPaletteFromAlbumArt(albumArt)
+            // Gated on the toggle for the same reason the seed extraction upstream is: with
+            // dynamic color theming off there is no palette and no seed, and falling through
+            // here would silently re-derive one from the bitmap anyway — the toggle would cost
+            // more than it saves and visibly do nothing.
+            albumArt != null && dynamicColorEnabled -> buildPaletteFromAlbumArt(albumArt)
             else -> DefaultWearPalette
         }
     }

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearDownloadsViewModel.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearDownloadsViewModel.kt
@@ -224,6 +224,14 @@ class WearDownloadsViewModel @Inject constructor(
         transferRepository.cancelTransfer(requestId)
     }
 
+    /**
+     * Dismiss a failed/cancelled transfer's chip from the "issues" section — otherwise it stays
+     * there indefinitely with no other way to clear it.
+     */
+    fun dismissTransfer(requestId: String) {
+        transferRepository.dismissTransfer(requestId)
+    }
+
     override fun onCleared() {
         phonePlaybackTimeoutJob?.cancel()
         super.onCleared()

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearLocalPlaylistViewModel.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearLocalPlaylistViewModel.kt
@@ -1,0 +1,136 @@
+package com.theveloper.pixelplay.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.theveloper.pixelplay.data.TransferState
+import com.theveloper.pixelplay.data.WearLocalPlayerRepository
+import com.theveloper.pixelplay.data.WearOutputTarget
+import com.theveloper.pixelplay.data.WearStateRepository
+import com.theveloper.pixelplay.data.local.LocalPlaylistDao
+import com.theveloper.pixelplay.data.local.LocalPlaylistEntity
+import com.theveloper.pixelplay.data.local.LocalSongDao
+import com.theveloper.pixelplay.data.local.LocalSongEntity
+import com.theveloper.pixelplay.data.WearTransferRepository
+import com.theveloper.pixelplay.shared.WearTransferProgress
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+
+/** A song's position in a local playlist snapshot, resolved against what's actually on disk. */
+data class WearLocalPlaylistSongItem(
+    val songId: String,
+    val song: LocalSongEntity?,
+    /** Best-effort name from the phone's playlist sync, shown only while [song] is null (still
+     *  pending transfer) — empty if the sync that created this row predates it. */
+    val pendingTitle: String = "",
+) {
+    val isAvailable: Boolean get() = song != null
+
+    /** Real title once transferred; otherwise the phone-provided pending title; the raw
+     *  [songId] only as a last resort, for a sync from a phone build old enough to not send one. */
+    val displayTitle: String get() = song?.title ?: pendingTitle.ifBlank { songId }
+}
+
+/**
+ * Backs [com.theveloper.pixelplay.presentation.screens.LocalPlaylistsScreen] and
+ * [com.theveloper.pixelplay.presentation.screens.LocalPlaylistDetailScreen]. Song availability is
+ * resolved reactively by joining the playlist's song order against [LocalSongDao.getAllSongs], so
+ * a song that finishes transferring while the detail screen is open flips from pending to
+ * playable without the user needing to back out and re-enter.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class WearLocalPlaylistViewModel @Inject constructor(
+    private val localPlaylistDao: LocalPlaylistDao,
+    private val localSongDao: LocalSongDao,
+    private val localPlayerRepository: WearLocalPlayerRepository,
+    private val stateRepository: WearStateRepository,
+    transferRepository: WearTransferRepository,
+) : ViewModel() {
+
+    val playlists: StateFlow<List<LocalPlaylistEntity>> = localPlaylistDao.observePlaylists()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), emptyList())
+
+    /** In-flight song transfers from the phone, keyed by requestId — for on-screen receive feedback. */
+    val activeTransfers: StateFlow<Map<String, TransferState>> = transferRepository.activeTransfers
+
+    /**
+     * Playlists that currently have at least one of their songs actively transferring.
+     *
+     * Only [WearTransferProgress.STATUS_TRANSFERRING] counts as "still receiving" — a failed or
+     * cancelled transfer stays in [WearTransferRepository.activeTransfers] indefinitely (so
+     * DownloadsScreen can list it under "Transfer issues"), but that's a terminal state, not an
+     * in-progress one. Treating mere presence in the map as "active" left this badge stuck on
+     * forever once a song failed.
+     */
+    val playlistIdsReceiving: StateFlow<Set<String>> = combine(
+        localPlaylistDao.observeAllPlaylistSongCrossRefs(),
+        transferRepository.activeTransfers,
+    ) { crossRefs, transfers ->
+        val activeSongIds = transfers.values
+            .filter { it.status == WearTransferProgress.STATUS_TRANSFERRING }
+            .map { it.songId }
+            .toSet()
+        if (activeSongIds.isEmpty()) {
+            emptySet()
+        } else {
+            crossRefs.filter { it.songId in activeSongIds }.map { it.playlistId }.toSet()
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), emptySet())
+
+    private val _playlistId = MutableStateFlow<String?>(null)
+
+    val playlistDetails: StateFlow<LocalPlaylistEntity?> = combine(
+        playlists,
+        _playlistId,
+    ) { allPlaylists, playlistId ->
+        allPlaylists.find { it.playlistId == playlistId }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), null)
+
+    val playlistSongs: StateFlow<List<WearLocalPlaylistSongItem>> = _playlistId
+        .flatMapLatest { playlistId ->
+            if (playlistId == null) {
+                flowOf(emptyList())
+            } else {
+                combine(
+                    localPlaylistDao.observePlaylistSongs(playlistId),
+                    localSongDao.getAllSongs(),
+                ) { crossRefs, allSongs ->
+                    val songsById = allSongs.associateBy { it.songId }
+                    crossRefs.map { ref ->
+                        WearLocalPlaylistSongItem(ref.songId, songsById[ref.songId], ref.pendingTitle)
+                    }
+                }
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), emptyList())
+
+    fun loadPlaylist(playlistId: String) {
+        if (_playlistId.value == playlistId) return
+        _playlistId.value = playlistId
+    }
+
+    /** Plays every available (already-transferred) song in order, from the start. */
+    fun playAll() {
+        val available = playlistSongs.value.mapNotNull { it.song }
+        if (available.isEmpty()) return
+        localPlayerRepository.playLocalSongs(available, startIndex = 0)
+        stateRepository.setOutputTarget(WearOutputTarget.WATCH)
+    }
+
+    /** Plays every available song, starting from [songId] — pending songs aren't tappable. */
+    fun playFrom(songId: String) {
+        val available = playlistSongs.value.mapNotNull { it.song }
+        val startIndex = available.indexOfFirst { it.songId == songId }
+        if (startIndex == -1) return
+        localPlayerRepository.playLocalSongs(available, startIndex = startIndex)
+        stateRepository.setOutputTarget(WearOutputTarget.WATCH)
+    }
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
@@ -132,6 +132,23 @@ class WearPlayerViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     /**
+     * Whether the theme may still derive its palette from the album art bitmap when no palette or
+     * seed is available. Without this, turning "dynamic color theming" off while "show album art"
+     * stays on would change nothing visible: [WearLocalPlayerRepository] clears the palette and
+     * the seed, and the theme would simply fall through to deriving one from the bitmap
+     * instead — on the main thread, via the *more* expensive path the toggle exists to avoid.
+     *
+     * Only restricted during local playback, same as [showPlayButtonAnimation]: in remote mode
+     * the palette comes from the phone, which honours the phone's own theming settings.
+     */
+    val dynamicColorThemingEnabled: StateFlow<Boolean> = combine(
+        stateRepository.outputTarget,
+        performanceSettingsRepository.dynamicColorTheming,
+    ) { target, dynamicColorEnabled ->
+        target != WearOutputTarget.WATCH || dynamicColorEnabled
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
+    /**
      * Whether the play button's continuous rotation/ring animation should run. Only restricted
      * during local playback — remote-controller mode never decodes anything heavy on the watch,
      * so there's nothing to save there and the full animation always shows.

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
@@ -144,8 +144,9 @@ class WearPlayerViewModel @Inject constructor(
     val dynamicColorThemingEnabled: StateFlow<Boolean> = combine(
         stateRepository.outputTarget,
         performanceSettingsRepository.dynamicColorTheming,
-    ) { target, dynamicColorEnabled ->
-        target != WearOutputTarget.WATCH || dynamicColorEnabled
+        performanceSettingsRepository.isResolved,
+    ) { target, dynamicColorEnabled, settingsResolved ->
+        target != WearOutputTarget.WATCH || (settingsResolved && dynamicColorEnabled)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     /**
@@ -156,8 +157,9 @@ class WearPlayerViewModel @Inject constructor(
     val showPlayButtonAnimation: StateFlow<Boolean> = combine(
         stateRepository.outputTarget,
         performanceSettingsRepository.playButtonAnimation,
-    ) { target, animationEnabled ->
-        target != WearOutputTarget.WATCH || animationEnabled
+        performanceSettingsRepository.isResolved,
+    ) { target, animationEnabled, settingsResolved ->
+        target != WearOutputTarget.WATCH || (settingsResolved && animationEnabled)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     val isPhoneConnected: StateFlow<Boolean> = stateRepository.isPhoneConnected

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
@@ -10,6 +10,7 @@ import com.theveloper.pixelplay.data.WearLifecycleState
 import com.theveloper.pixelplay.data.WearLocalQueueState
 import com.theveloper.pixelplay.data.WearLocalPlayerRepository
 import com.theveloper.pixelplay.data.WearOutputTarget
+import com.theveloper.pixelplay.data.WearPerformanceSettingsRepository
 import com.theveloper.pixelplay.data.WearPlaybackController
 import com.theveloper.pixelplay.data.WearStateRepository
 import com.theveloper.pixelplay.data.WearTransferRepository
@@ -49,6 +50,7 @@ class WearPlayerViewModel @Inject constructor(
     private val transferRepository: WearTransferRepository,
     private val volumeRepository: WearVolumeRepository,
     private val favoriteSyncRepository: WearFavoriteSyncRepository,
+    private val performanceSettingsRepository: WearPerformanceSettingsRepository,
 ) : ViewModel() {
     companion object {
         private const val PHONE_SYNC_BOOTSTRAP_ATTEMPTS = 3
@@ -129,6 +131,18 @@ class WearPlayerViewModel @Inject constructor(
     }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
+    /**
+     * Whether the play button's continuous rotation/ring animation should run. Only restricted
+     * during local playback — remote-controller mode never decodes anything heavy on the watch,
+     * so there's nothing to save there and the full animation always shows.
+     */
+    val showPlayButtonAnimation: StateFlow<Boolean> = combine(
+        stateRepository.outputTarget,
+        performanceSettingsRepository.playButtonAnimation,
+    ) { target, animationEnabled ->
+        target != WearOutputTarget.WATCH || animationEnabled
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
     val isPhoneConnected: StateFlow<Boolean> = stateRepository.isPhoneConnected
     val phoneVolumeState: StateFlow<WearVolumeState> = stateRepository.volumeState
     val watchVolumeState: StateFlow<WearVolumeState> = volumeRepository.watchVolumeState
@@ -200,6 +214,18 @@ class WearPlayerViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     init {
+        viewModelScope.launch {
+            // Recovers a queue/position that survived a process death mid-playback (see
+            // WearLocalPlayerRepository's KDoc) — a no-op whenever nothing was persisted, which
+            // is the overwhelming majority of app opens. `outputTarget` itself isn't persisted
+            // (WearStateRepository always starts at PHONE), so a successful restore is the
+            // signal that the user actually was on watch-local playback; it wouldn't otherwise
+            // be visible in `playerState` until switched here.
+            val restored = localPlayerRepository.restorePersistedPlaybackIfAvailable()
+            if (restored) {
+                stateRepository.setOutputTarget(WearOutputTarget.WATCH)
+            }
+        }
         viewModelScope.launch {
             outputTarget.collect {
                 refreshActiveVolumeState()

--- a/wear/src/main/res/raw/keep.xml
+++ b/wear/src/main/res/raw/keep.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The resource shrinker (isShrinkResources = true in release) only sees resources reached via
+  code references (R.array.foo, @array/foo in XML, etc). android_wear_capabilities is never
+  referenced that way — Google Play Services discovers it purely by resource NAME convention to
+  advertise this app's Wear capabilities (see WearCapabilities.PIXELPLAY_WEAR_APP), so the
+  shrinker's reachability analysis correctly, but wrongly for our purposes, considers it unused
+  and strips it from release builds. Confirmed via wear/build/outputs/mapping/release/resources.txt:
+  "array:android_wear_capabilities:... is not reachable." This keeps it in the APK.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@array/android_wear_capabilities" />

--- a/wear/src/main/res/values-de/strings_wear.xml
+++ b/wear/src/main/res/values-de/strings_wear.xml
@@ -7,6 +7,7 @@
     <string name="wear_transfer_issues">Übertragungsprobleme</string>
     <string name="wear_transfer_cancelled">Abgebrochen</string>
     <string name="wear_transfer_failed">Übertragung fehlgeschlagen</string>
+    <string name="wear_transfer_dismiss_hint">Zum Ausblenden tippen</string>
     <string name="wear_saved_from_phone">Vom Telefon gespeichert</string>
     <string name="wear_songs_watch_storage">Songs auf dem Uhr-Speicher</string>
     <string name="wear_allow_audio_access">Audiozugriff erlauben</string>

--- a/wear/src/main/res/values-es/strings_wear.xml
+++ b/wear/src/main/res/values-es/strings_wear.xml
@@ -7,6 +7,7 @@
     <string name="wear_transfer_issues">Problemas de transferencia</string>
     <string name="wear_transfer_cancelled">Cancelada</string>
     <string name="wear_transfer_failed">Error en la transferencia</string>
+    <string name="wear_transfer_dismiss_hint">Toca para descartar</string>
     <string name="wear_saved_from_phone">Guardado desde el teléfono</string>
     <string name="wear_songs_watch_storage">Canciones en el almacenamiento del reloj</string>
     <string name="wear_allow_audio_access">Permitir acceso al audio</string>
@@ -14,6 +15,14 @@
     <string name="wear_scanning_watch_storage">Escaneando almacenamiento del reloj…</string>
     <string name="wear_retry_scan">Reintentar escaneo</string>
     <string name="wear_no_local_songs">No se encontraron canciones locales</string>
+    <string name="wear_playlists_title">Listas de reproducción</string>
+    <string name="wear_no_local_playlists">Aún no se ha enviado ninguna lista desde tu teléfono</string>
+    <string name="wear_playlist_receiving">Recibiendo…</string>
+    <string name="wear_local_playlists_entry">Listas de reproducción</string>
+    <string name="wear_playlist_pending_songs">%1$d de %2$d disponibles</string>
+    <string name="wear_play_all">Reproducir todo</string>
+    <string name="wear_playlist_empty">Esta lista no tiene canciones</string>
+    <string name="wear_song_pending_transfer">Esperando transferencia…</string>
     <string name="wear_status_playing">Reproduciendo</string>
     <string name="wear_status_current">Actual</string>
     <string name="wear_cd_more_options">Más opciones</string>

--- a/wear/src/main/res/values-ko/strings_wear.xml
+++ b/wear/src/main/res/values-ko/strings_wear.xml
@@ -7,6 +7,7 @@
     <string name="wear_transfer_issues">전송 문제</string>
     <string name="wear_transfer_cancelled">취소됨</string>
     <string name="wear_transfer_failed">전송 실패</string>
+    <string name="wear_transfer_dismiss_hint">탭하여 닫기</string>
     <string name="wear_saved_from_phone">휴대전화에서 저장됨</string>
     <string name="wear_songs_watch_storage">워치 저장공간의 곡</string>
     <string name="wear_allow_audio_access">오디오 액세스 허용</string>

--- a/wear/src/main/res/values-nb/strings_wear.xml
+++ b/wear/src/main/res/values-nb/strings_wear.xml
@@ -7,6 +7,7 @@
     <string name="wear_transfer_issues">Overføringsproblemer</string>
     <string name="wear_transfer_cancelled">Avbrutt</string>
     <string name="wear_transfer_failed">Overføring feilet</string>
+    <string name="wear_transfer_dismiss_hint">Trykk for å avvise</string>
     <string name="wear_saved_from_phone">Lagret fra telefonen</string>
     <string name="wear_songs_watch_storage">Sanger på klokkens lagring</string>
     <string name="wear_allow_audio_access">Tillat lydtilgang</string>

--- a/wear/src/main/res/values-ru/strings_wear.xml
+++ b/wear/src/main/res/values-ru/strings_wear.xml
@@ -7,6 +7,7 @@
     <string name="wear_transfer_issues">Проблемы с передачей</string>
     <string name="wear_transfer_cancelled">Отменено</string>
     <string name="wear_transfer_failed">Передача не удалась</string>
+    <string name="wear_transfer_dismiss_hint">Нажмите, чтобы скрыть</string>
     <string name="wear_saved_from_phone">Сохранено с телефона</string>
     <string name="wear_songs_watch_storage">Песни в памяти часов</string>
     <string name="wear_allow_audio_access">Разрешить доступ к аудио</string>

--- a/wear/src/main/res/values/strings_wear.xml
+++ b/wear/src/main/res/values/strings_wear.xml
@@ -7,6 +7,7 @@
     <string name="wear_transfer_issues">Transfer issues</string>
     <string name="wear_transfer_cancelled">Cancelled</string>
     <string name="wear_transfer_failed">Transfer failed</string>
+    <string name="wear_transfer_dismiss_hint">Tap to dismiss</string>
     <string name="wear_saved_from_phone">Saved from phone</string>
     <string name="wear_songs_watch_storage">Songs on watch storage</string>
     <string name="wear_allow_audio_access">Allow audio access</string>
@@ -14,6 +15,14 @@
     <string name="wear_scanning_watch_storage">Scanning watch storage…</string>
     <string name="wear_retry_scan">Retry scan</string>
     <string name="wear_no_local_songs">No local songs found</string>
+    <string name="wear_playlists_title">Playlists</string>
+    <string name="wear_no_local_playlists">No playlists sent from your phone yet</string>
+    <string name="wear_playlist_receiving">Receiving…</string>
+    <string name="wear_local_playlists_entry">Playlists</string>
+    <string name="wear_playlist_pending_songs">%1$d of %2$d ready</string>
+    <string name="wear_play_all">Play all</string>
+    <string name="wear_playlist_empty">This playlist has no songs</string>
+    <string name="wear_song_pending_transfer">Waiting to transfer…</string>
     <string name="wear_status_playing">Playing</string>
     <string name="wear_status_current">Current</string>
     <string name="wear_cd_more_options">More options</string>

--- a/wear/src/test/java/com/theveloper/pixelplay/MainCoroutineExtension.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/MainCoroutineExtension.kt
@@ -1,0 +1,24 @@
+package com.theveloper.pixelplay
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+@ExperimentalCoroutinesApi
+class MainCoroutineExtension(private val testDispatcher: TestDispatcher = StandardTestDispatcher()) :
+    BeforeEachCallback, AfterEachCallback {
+
+    override fun beforeEach(context: ExtensionContext) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        Dispatchers.resetMain()
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearAudioOffloadPolicyTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearAudioOffloadPolicyTest.kt
@@ -1,0 +1,87 @@
+package com.theveloper.pixelplay.data
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class WearAudioOffloadPolicyTest {
+
+    @Test
+    fun earlyBuffering_fallsBackForGenuineHalReset() {
+        val shouldFallBack = wearShouldFallBackFromAudioOffload(
+            audioOffloadEnabled = true,
+            lastPlayingAtMs = 1_000L,
+            timeSincePlayingMs = 120L,
+            isPostSeekBuffering = false,
+            isPostMediaItemTransition = false,
+        )
+
+        assertThat(shouldFallBack).isTrue()
+    }
+
+    @Test
+    fun earlyBuffering_doesNotFallBackWhenOffloadIsAlreadyDisabled() {
+        val shouldFallBack = wearShouldFallBackFromAudioOffload(
+            audioOffloadEnabled = false,
+            lastPlayingAtMs = 1_000L,
+            timeSincePlayingMs = 120L,
+            isPostSeekBuffering = false,
+            isPostMediaItemTransition = false,
+        )
+
+        assertThat(shouldFallBack).isFalse()
+    }
+
+    @Test
+    fun earlyBuffering_doesNotFallBackRightAfterASeek() {
+        val shouldFallBack = wearShouldFallBackFromAudioOffload(
+            audioOffloadEnabled = true,
+            lastPlayingAtMs = 1_000L,
+            timeSincePlayingMs = 120L,
+            isPostSeekBuffering = true,
+            isPostMediaItemTransition = false,
+        )
+
+        assertThat(shouldFallBack).isFalse()
+    }
+
+    @Test
+    fun earlyBuffering_doesNotFallBackRightAfterATrackChange() {
+        val shouldFallBack = wearShouldFallBackFromAudioOffload(
+            audioOffloadEnabled = true,
+            lastPlayingAtMs = 1_000L,
+            timeSincePlayingMs = 120L,
+            isPostSeekBuffering = false,
+            isPostMediaItemTransition = true,
+        )
+
+        assertThat(shouldFallBack).isFalse()
+    }
+
+    @Test
+    fun earlyBuffering_doesNotFallBackAfterLongSteadyPlayback() {
+        val shouldFallBack = wearShouldFallBackFromAudioOffload(
+            audioOffloadEnabled = true,
+            lastPlayingAtMs = 1_000L,
+            timeSincePlayingMs = 5_000L,
+            isPostSeekBuffering = false,
+            isPostMediaItemTransition = false,
+        )
+
+        assertThat(shouldFallBack).isFalse()
+    }
+
+    @Test
+    fun earlyBuffering_doesNotFallBackBeforeAnyPlaybackEverStarted() {
+        // lastPlayingAtMs == 0L means playback never reached PLAYING yet — the very first
+        // buffer-up on cold start is not an offload HAL reset.
+        val shouldFallBack = wearShouldFallBackFromAudioOffload(
+            audioOffloadEnabled = true,
+            lastPlayingAtMs = 0L,
+            timeSincePlayingMs = 120L,
+            isPostSeekBuffering = false,
+            isPostMediaItemTransition = false,
+        )
+
+        assertThat(shouldFallBack).isFalse()
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearLoadControlProfileTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearLoadControlProfileTest.kt
@@ -1,0 +1,49 @@
+package com.theveloper.pixelplay.data
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class WearLoadControlProfileTest {
+
+    @Test
+    fun normalDevice_usesFullPrefetchProfile() {
+        val profile = wearLoadControlBufferProfileFor(isLowRamDevice = false)
+
+        assertThat(profile.minBufferMs).isEqualTo(30_000)
+        assertThat(profile.maxBufferMs).isEqualTo(60_000)
+        assertThat(profile.bufferForPlaybackMs).isEqualTo(2_500)
+        assertThat(profile.bufferForPlaybackAfterRebufferMs).isEqualTo(5_000)
+    }
+
+    @Test
+    fun lowRamDevice_cutsPrefetchWindow() {
+        val normal = wearLoadControlBufferProfileFor(isLowRamDevice = false)
+        val lowRam = wearLoadControlBufferProfileFor(isLowRamDevice = true)
+
+        assertThat(lowRam.maxBufferMs).isLessThan(normal.maxBufferMs)
+        assertThat(lowRam.minBufferMs).isLessThan(normal.minBufferMs)
+    }
+
+    @Test
+    fun lowRamDevice_keepsStartLatencyIdenticalToNormal() {
+        // Capping the prefetch window must not regress how quickly playback actually starts.
+        val normal = wearLoadControlBufferProfileFor(isLowRamDevice = false)
+        val lowRam = wearLoadControlBufferProfileFor(isLowRamDevice = true)
+
+        assertThat(lowRam.bufferForPlaybackMs).isEqualTo(normal.bufferForPlaybackMs)
+        assertThat(lowRam.bufferForPlaybackAfterRebufferMs)
+            .isEqualTo(normal.bufferForPlaybackAfterRebufferMs)
+    }
+
+    @Test
+    fun bothProfiles_satisfyDefaultLoadControlConstraints() {
+        for (isLowRam in listOf(false, true)) {
+            val profile = wearLoadControlBufferProfileFor(isLowRam)
+
+            // DefaultLoadControl.Builder.build() asserts these; violating them crashes at runtime.
+            assertThat(profile.minBufferMs).isAtLeast(profile.bufferForPlaybackMs)
+            assertThat(profile.minBufferMs).isAtLeast(profile.bufferForPlaybackAfterRebufferMs)
+            assertThat(profile.maxBufferMs).isAtLeast(profile.minBufferMs)
+        }
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepositoryTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepositoryTest.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlinx.coroutines.CoroutineScope
@@ -37,7 +38,9 @@ class WearPerformanceSettingsRepositoryTest {
             scope = dataStoreScope,
             produceFile = { tempDir.resolve("settings.preferences_pb").toFile() },
         )
-        repository = WearPerformanceSettingsRepository(dataStore)
+        // Only the DataStore-backed behavior is covered here; refreshFromPhone() drives a real
+        // Play Services DataClient and is device-verified, so a relaxed mock is enough to build.
+        repository = WearPerformanceSettingsRepository(dataStore, mockk(relaxed = true))
     }
 
     @AfterEach

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepositoryTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearPerformanceSettingsRepositoryTest.kt
@@ -1,0 +1,111 @@
+package com.theveloper.pixelplay.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The StateFlows here are `stateIn(..., SharingStarted.Eagerly, true)` on the repository's own
+ * background scope, not the test's — so round-trip assertions use Turbine's `awaitItem()`
+ * (properly suspends for the async DataStore write to propagate) rather than reading `.value`
+ * immediately after `save()`, which would race the background collector.
+ */
+class WearPerformanceSettingsRepositoryTest {
+
+    private lateinit var dataStoreScope: CoroutineScope
+    private lateinit var tempDir: Path
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repository: WearPerformanceSettingsRepository
+
+    @BeforeEach
+    fun setUp() {
+        tempDir = Files.createTempDirectory("wear-performance-settings-test")
+        dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = dataStoreScope,
+            produceFile = { tempDir.resolve("settings.preferences_pb").toFile() },
+        )
+        repository = WearPerformanceSettingsRepository(dataStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        dataStoreScope.cancel()
+        tempDir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `all three default to true when nothing has been persisted`() = runTest {
+        // stateIn's initialValue is available synchronously, before any real collection has
+        // started, so this is safe to read without awaiting anything.
+        assertThat(repository.showAlbumArt.value).isTrue()
+        assertThat(repository.dynamicColorTheming.value).isTrue()
+        assertThat(repository.playButtonAnimation.value).isTrue()
+    }
+
+    @Test
+    fun `save propagates false for showAlbumArt through its StateFlow`() = runTest {
+        repository.showAlbumArt.test {
+            assertThat(awaitItem()).isTrue()
+            repository.save(showAlbumArt = false, dynamicColorTheming = true, playButtonAnimation = true)
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `save propagates false for dynamicColorTheming through its StateFlow`() = runTest {
+        repository.dynamicColorTheming.test {
+            assertThat(awaitItem()).isTrue()
+            repository.save(showAlbumArt = true, dynamicColorTheming = false, playButtonAnimation = true)
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `save propagates false for playButtonAnimation through its StateFlow`() = runTest {
+        repository.playButtonAnimation.test {
+            assertThat(awaitItem()).isTrue()
+            repository.save(showAlbumArt = true, dynamicColorTheming = true, playButtonAnimation = false)
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `saving one flag false does not affect the other two`() = runTest {
+        repository.showAlbumArt.test {
+            assertThat(awaitItem()).isTrue()
+            repository.save(showAlbumArt = false, dynamicColorTheming = true, playButtonAnimation = true)
+            assertThat(awaitItem()).isFalse()
+
+            // The other two flows aren't being collected here, but a second save that changes
+            // only showAlbumArt back should still round-trip correctly, confirming save() writes
+            // exactly the three values passed rather than something order-dependent.
+            repository.save(showAlbumArt = true, dynamicColorTheming = false, playButtonAnimation = false)
+            assertThat(awaitItem()).isTrue()
+        }
+        assertThat(repository.dynamicColorTheming.value).isFalse()
+        assertThat(repository.playButtonAnimation.value).isFalse()
+    }
+
+    @Test
+    fun `a later save overwrites an earlier one, not merges`() = runTest {
+        repository.save(showAlbumArt = false, dynamicColorTheming = false, playButtonAnimation = false)
+        repository.save(showAlbumArt = true, dynamicColorTheming = true, playButtonAnimation = true)
+
+        repository.showAlbumArt.test {
+            assertThat(awaitItem()).isTrue()
+        }
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearPlaybackStallWatchdogTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearPlaybackStallWatchdogTest.kt
@@ -1,0 +1,76 @@
+package com.theveloper.pixelplay.data
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class WearPlaybackStallWatchdogTest {
+
+    @Test
+    fun `not playing resets the counter to zero`() {
+        val result = wearPlaybackStalledTickCount(
+            isPlaying = false,
+            positionAdvancedSinceLastTick = false,
+            previousConsecutiveStalledTicks = 2,
+        )
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `playing with position advancing resets the counter to zero`() {
+        val result = wearPlaybackStalledTickCount(
+            isPlaying = true,
+            positionAdvancedSinceLastTick = true,
+            previousConsecutiveStalledTicks = 2,
+        )
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `playing with a frozen position increments the counter`() {
+        val result = wearPlaybackStalledTickCount(
+            isPlaying = true,
+            positionAdvancedSinceLastTick = false,
+            previousConsecutiveStalledTicks = 1,
+        )
+
+        assertThat(result).isEqualTo(2)
+    }
+
+    @Test
+    fun `a frozen position starting from zero counts as one stalled tick`() {
+        val result = wearPlaybackStalledTickCount(
+            isPlaying = true,
+            positionAdvancedSinceLastTick = false,
+            previousConsecutiveStalledTicks = 0,
+        )
+
+        assertThat(result).isEqualTo(1)
+    }
+
+    @Test
+    fun `a single advancing tick after several stalled ones fully resets, not decrements`() {
+        val result = wearPlaybackStalledTickCount(
+            isPlaying = true,
+            positionAdvancedSinceLastTick = true,
+            previousConsecutiveStalledTicks = 5,
+        )
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `three consecutive stalled ticks reaches the production threshold`() {
+        var ticks = 0
+        repeat(3) {
+            ticks = wearPlaybackStalledTickCount(
+                isPlaying = true,
+                positionAdvancedSinceLastTick = false,
+                previousConsecutiveStalledTicks = ticks,
+            )
+        }
+
+        assertThat(ticks).isEqualTo(3)
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearPlaybackStatePersistenceTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearPlaybackStatePersistenceTest.kt
@@ -1,0 +1,105 @@
+package com.theveloper.pixelplay.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.google.common.truth.Truth.assertThat
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class WearPlaybackStatePersistenceTest {
+
+    // Same reasoning as PlaylistBatchTransferPersistenceTest in :app: DataStore's internal
+    // write-actor needs a scope that outlives any single test method's own runTest {} block.
+    private lateinit var dataStoreScope: CoroutineScope
+    private lateinit var tempDir: Path
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var persistence: WearPlaybackStatePersistence
+
+    @BeforeEach
+    fun setUp() {
+        tempDir = Files.createTempDirectory("wear-playback-state-persistence-test")
+        dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = dataStoreScope,
+            produceFile = { tempDir.resolve("settings.preferences_pb").toFile() },
+        )
+        persistence = WearPlaybackStatePersistence(dataStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        dataStoreScope.cancel()
+        tempDir.toFile().deleteRecursively()
+    }
+
+    private fun state(
+        queueSongIds: List<String> = listOf("s1", "s2"),
+        currentIndex: Int = 0,
+        positionMs: Long = 12_345L,
+        updatedAtMillis: Long = 1_000L,
+    ) = PersistedLocalPlaybackState(
+        queueSongIds = queueSongIds,
+        currentIndex = currentIndex,
+        positionMs = positionMs,
+        updatedAtMillis = updatedAtMillis,
+    )
+
+    @Test
+    fun `nothing persisted returns null`() = runTest {
+        assertThat(persistence.read()).isNull()
+    }
+
+    @Test
+    fun `save then read round-trips the state`() = runTest {
+        val saved = state()
+        persistence.save(saved)
+
+        assertThat(persistence.read()).isEqualTo(saved)
+    }
+
+    @Test
+    fun `saving again overwrites the previous state`() = runTest {
+        persistence.save(state(currentIndex = 0, positionMs = 1_000L))
+        persistence.save(state(currentIndex = 1, positionMs = 5_000L))
+
+        val read = persistence.read()
+        assertThat(read?.currentIndex).isEqualTo(1)
+        assertThat(read?.positionMs).isEqualTo(5_000L)
+    }
+
+    @Test
+    fun `clearing removes the stored state`() = runTest {
+        persistence.save(state())
+
+        persistence.clear()
+
+        assertThat(persistence.read()).isNull()
+    }
+
+    @Test
+    fun `clearing when nothing is stored does not throw`() = runTest {
+        persistence.clear()
+
+        assertThat(persistence.read()).isNull()
+    }
+
+    @Test
+    fun `malformed stored data is treated as nothing persisted, not a crash`() = runTest {
+        dataStore.edit { preferences ->
+            preferences[stringPreferencesKey("wear_local_playback_state_v1")] = "{not valid json"
+        }
+
+        assertThat(persistence.read()).isNull()
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearPlaybackStateRestorabilityTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearPlaybackStateRestorabilityTest.kt
@@ -1,0 +1,85 @@
+package com.theveloper.pixelplay.data
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class WearPlaybackStateRestorabilityTest {
+
+    private val oneHourMs = 60 * 60 * 1000L
+
+    private fun state(
+        queueSongIds: List<String> = listOf("s1", "s2"),
+        currentIndex: Int = 0,
+        updatedAtMillis: Long = 0L,
+    ) = PersistedLocalPlaybackState(
+        queueSongIds = queueSongIds,
+        currentIndex = currentIndex,
+        positionMs = 1_000L,
+        updatedAtMillis = updatedAtMillis,
+    )
+
+    @Test
+    fun `a recent state with a valid index is restorable`() {
+        val restorable = isPersistedLocalPlaybackStateRestorable(
+            state = state(updatedAtMillis = 0L),
+            nowMillis = oneHourMs,
+        )
+
+        assertThat(restorable).isTrue()
+    }
+
+    @Test
+    fun `an empty queue is never restorable`() {
+        val restorable = isPersistedLocalPlaybackStateRestorable(
+            state = state(queueSongIds = emptyList(), currentIndex = 0, updatedAtMillis = 0L),
+            nowMillis = 0L,
+        )
+
+        assertThat(restorable).isFalse()
+    }
+
+    @Test
+    fun `an out-of-range index is not restorable`() {
+        val restorable = isPersistedLocalPlaybackStateRestorable(
+            state = state(queueSongIds = listOf("s1"), currentIndex = 5, updatedAtMillis = 0L),
+            nowMillis = 0L,
+        )
+
+        assertThat(restorable).isFalse()
+    }
+
+    @Test
+    fun `a state older than the max age is not restorable`() {
+        val maxAge = 6 * oneHourMs
+        val restorable = isPersistedLocalPlaybackStateRestorable(
+            state = state(updatedAtMillis = 0L),
+            nowMillis = maxAge + 1L,
+            maxAgeMillis = maxAge,
+        )
+
+        assertThat(restorable).isFalse()
+    }
+
+    @Test
+    fun `a state exactly at the max age boundary is still restorable`() {
+        val maxAge = 6 * oneHourMs
+        val restorable = isPersistedLocalPlaybackStateRestorable(
+            state = state(updatedAtMillis = 0L),
+            nowMillis = maxAge,
+            maxAgeMillis = maxAge,
+        )
+
+        assertThat(restorable).isTrue()
+    }
+
+    @Test
+    fun `a state with a future timestamp is not restorable`() {
+        // Defensive: clock skew or a corrupted timestamp shouldn't be treated as "very fresh".
+        val restorable = isPersistedLocalPlaybackStateRestorable(
+            state = state(updatedAtMillis = 10_000L),
+            nowMillis = 0L,
+        )
+
+        assertThat(restorable).isFalse()
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryOutcomeTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryOutcomeTest.kt
@@ -1,0 +1,186 @@
+package com.theveloper.pixelplay.data
+
+import android.app.Application
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wearable.ChannelClient
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.NodeClient
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.MainCoroutineExtension
+import com.theveloper.pixelplay.data.local.LocalPlaylistDao
+import com.theveloper.pixelplay.data.local.LocalSongDao
+import com.theveloper.pixelplay.shared.WearDataPaths
+import com.theveloper.pixelplay.shared.WearTransferMetadata
+import com.theveloper.pixelplay.shared.WearTransferProgress
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+/**
+ * Covers [WearTransferRepository.onMetadataReceived]'s ack to the phone and
+ * [WearTransferRepository.dismissTransfer] — the phone-reliability fix (the watch reporting its
+ * real outcome instead of the phone trusting its own send-completion) and the "can't clear a
+ * failed transfer chip" UX fix, both from the same session.
+ *
+ * The channel-streaming success/failure paths (`onAudioChannelOpened` and everything downstream)
+ * aren't covered here: they run on the repository's own background `scope`, not on the test
+ * dispatcher, so asserting on them deterministically needs the on-device coverage this class
+ * already leans on for that surface (see [WearTransferRepositoryPlaylistSyncTest]'s doc comment).
+ * The "already on watch" case below uses the phone-rejected-with-`error` path rather than the
+ * existing-local-file check for the same reason: the latter needs a real file on disk.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class WearTransferRepositoryOutcomeTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainCoroutineExtension = MainCoroutineExtension()
+    }
+
+    private val application = mockk<Application>(relaxed = true)
+    private val localSongDao = mockk<LocalSongDao>()
+    private val localPlaylistDao = mockk<LocalPlaylistDao>()
+    private val channelClient = mockk<ChannelClient>()
+    private val messageClient = mockk<MessageClient>()
+    private val nodeClient = mockk<NodeClient>()
+
+    private lateinit var repository: WearTransferRepository
+
+    private fun metadata(requestId: String, songId: String, error: String? = null) = WearTransferMetadata(
+        requestId = requestId,
+        songId = songId,
+        title = "Title",
+        artist = "Artist",
+        album = "Album",
+        albumId = 1L,
+        duration = 1000L,
+        mimeType = "audio/mpeg",
+        fileSize = 4096L,
+        bitrate = 128_000,
+        sampleRate = 44_100,
+        isFavorite = false,
+        error = error,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        every { localSongDao.getAllSongs() } returns flowOf(emptyList())
+        coEvery { localSongDao.getSongById(any()) } returns null
+
+        val stateRepository = WearStateRepository()
+        val performanceSettingsRepository = mockk<WearPerformanceSettingsRepository> {
+            every { showAlbumArt } returns MutableStateFlow(true)
+            every { dynamicColorTheming } returns MutableStateFlow(true)
+            every { playButtonAnimation } returns MutableStateFlow(true)
+        }
+        val localPlayerRepository = WearLocalPlayerRepository(
+            application,
+            localSongDao,
+            mockk<WearPlaybackStatePersistence>(),
+            performanceSettingsRepository,
+        )
+        val playbackController = WearPlaybackController(application, stateRepository)
+
+        repository = WearTransferRepository(
+            application = application,
+            localSongDao = localSongDao,
+            localPlaylistDao = localPlaylistDao,
+            channelClient = channelClient,
+            messageClient = messageClient,
+            nodeClient = nodeClient,
+            localPlayerRepository = localPlayerRepository,
+            stateRepository = stateRepository,
+            playbackController = playbackController,
+        )
+    }
+
+    @Test
+    fun `metadata received acks back to the source node before the audio channel opens`() = runTest {
+        val pathSlot = slot<String>()
+        val bytesSlot = slot<ByteArray>()
+        every { messageClient.sendMessage("node-9", capture(pathSlot), capture(bytesSlot)) } returns
+            Tasks.forResult(0)
+
+        repository.onMetadataReceived(metadata(requestId = "req-1", songId = "song-1"), sourceNodeId = "node-9")
+
+        assertThat(pathSlot.captured).isEqualTo(WearDataPaths.TRANSFER_PROGRESS)
+        val progress = Json.decodeFromString<WearTransferProgress>(String(bytesSlot.captured, Charsets.UTF_8))
+        assertThat(progress.requestId).isEqualTo("req-1")
+        assertThat(progress.songId).isEqualTo("song-1")
+        assertThat(progress.status).isEqualTo(WearTransferProgress.STATUS_METADATA_RECEIVED)
+    }
+
+    @Test
+    fun `metadata received with no sourceNodeId sends no ack`() = runTest {
+        repository.onMetadataReceived(metadata(requestId = "req-1", songId = "song-1"), sourceNodeId = null)
+
+        verify(exactly = 0) { messageClient.sendMessage(any(), any(), any()) }
+    }
+
+    @Test
+    fun `phone-side rejection reports STATUS_FAILED with the phone's error to the phone`() = runTest {
+        val rejected = metadata(
+            requestId = "req-2",
+            songId = "song-2",
+            error = "Song must be downloaded locally on phone before saving to watch",
+        )
+        val pathSlot = slot<String>()
+        val bytesSlot = slot<ByteArray>()
+        every { messageClient.sendMessage("node-9", capture(pathSlot), capture(bytesSlot)) } returns
+            Tasks.forResult(0)
+
+        repository.onMetadataReceived(rejected, sourceNodeId = "node-9")
+
+        // The errorMsg != null branch returns before the metadata-received ack point, so this
+        // is the only message sent for this requestId.
+        assertThat(pathSlot.captured).isEqualTo(WearDataPaths.TRANSFER_PROGRESS)
+        val progress = Json.decodeFromString<WearTransferProgress>(String(bytesSlot.captured, Charsets.UTF_8))
+        assertThat(progress.status).isEqualTo(WearTransferProgress.STATUS_FAILED)
+        assertThat(progress.error).isEqualTo(rejected.error)
+    }
+
+    @Test
+    fun `dismissTransfer removes a failed entry`() = runTest {
+        every { messageClient.sendMessage(any(), any(), any()) } returns Tasks.forResult(0)
+
+        // First call seeds an active-transfer entry (the error branch below never creates one on
+        // its own — there's nothing to flip from null to FAILED without a prior entry).
+        repository.onMetadataReceived(metadata(requestId = "req-3", songId = "song-3"), sourceNodeId = "node-9")
+        repository.onMetadataReceived(
+            metadata(
+                requestId = "req-3",
+                songId = "song-3",
+                error = "Song must be downloaded locally on phone before saving to watch",
+            ),
+            sourceNodeId = "node-9",
+        )
+        assertThat(repository.activeTransfers.value["req-3"]?.status).isEqualTo(WearTransferProgress.STATUS_FAILED)
+
+        repository.dismissTransfer("req-3")
+
+        assertThat(repository.activeTransfers.value).doesNotContainKey("req-3")
+    }
+
+    @Test
+    fun `dismissTransfer is a no-op for a transfer that is not in a terminal state`() = runTest {
+        every { messageClient.sendMessage(any(), any(), any()) } returns Tasks.forResult(0)
+
+        repository.onMetadataReceived(metadata(requestId = "req-4", songId = "song-4"), sourceNodeId = "node-9")
+        assertThat(repository.activeTransfers.value["req-4"]?.status).isEqualTo(WearTransferProgress.STATUS_TRANSFERRING)
+
+        repository.dismissTransfer("req-4")
+
+        assertThat(repository.activeTransfers.value).containsKey("req-4")
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryOutcomeTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryOutcomeTest.kt
@@ -83,6 +83,9 @@ class WearTransferRepositoryOutcomeTest {
             every { showAlbumArt } returns MutableStateFlow(true)
             every { dynamicColorTheming } returns MutableStateFlow(true)
             every { playButtonAnimation } returns MutableStateFlow(true)
+            // Already resolved: these tests are about transfer/playlist behavior, not about the
+            // startup window where the toggles aren't known yet.
+            every { isResolved } returns MutableStateFlow(true)
         }
         val localPlayerRepository = WearLocalPlayerRepository(
             application,

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryPlaylistSyncTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryPlaylistSyncTest.kt
@@ -1,0 +1,281 @@
+package com.theveloper.pixelplay.data
+
+import android.app.Application
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wearable.ChannelClient
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.NodeClient
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.MainCoroutineExtension
+import com.theveloper.pixelplay.data.local.LocalPlaylistDao
+import com.theveloper.pixelplay.data.local.LocalPlaylistEntity
+import com.theveloper.pixelplay.data.local.LocalPlaylistSongCrossRef
+import com.theveloper.pixelplay.data.local.LocalSongDao
+import com.theveloper.pixelplay.shared.WearDataPaths
+import com.theveloper.pixelplay.shared.WearPlaylistSync
+import com.theveloper.pixelplay.shared.WearPlaylistSyncAck
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+/**
+ * Covers [WearTransferRepository.onPlaylistSyncReceived] only — everything else on the repository
+ * (song-by-song ChannelClient transfer, artwork, watchdogs) is exercised on-device, not here.
+ *
+ * [WearLocalPlayerRepository] and [WearPlaybackController] are constructed for real rather than
+ * mocked: both are final Kotlin classes (no `open`), so MockK could only fake them via its
+ * inline-mocking Java agent — which hangs indefinitely under this sandbox (see
+ * `PlaylistWatchTransferCoordinatorTest` in `:app` for the same constraint on the GMS side).
+ * Real construction needs no agent and is safe here because `onPlaylistSyncReceived` never calls
+ * either collaborator; [MainCoroutineExtension] supplies the `Dispatchers.Main` both of their
+ * `init` blocks need to launch on.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class WearTransferRepositoryPlaylistSyncTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainCoroutineExtension = MainCoroutineExtension()
+    }
+
+    private val application = mockk<Application>(relaxed = true)
+    private val localSongDao = mockk<LocalSongDao>()
+    private val localPlaylistDao = mockk<LocalPlaylistDao>()
+    private val channelClient = mockk<ChannelClient>()
+    private val messageClient = mockk<MessageClient>()
+    private val nodeClient = mockk<NodeClient>()
+
+    private lateinit var repository: WearTransferRepository
+
+    @BeforeEach
+    fun setUp() {
+        every { localSongDao.getAllSongs() } returns flowOf(emptyList())
+        coEvery { localPlaylistDao.upsertPlaylist(any(), any()) } just Runs
+
+        val stateRepository = WearStateRepository()
+        val performanceSettingsRepository = mockk<WearPerformanceSettingsRepository> {
+            every { showAlbumArt } returns MutableStateFlow(true)
+            every { dynamicColorTheming } returns MutableStateFlow(true)
+            every { playButtonAnimation } returns MutableStateFlow(true)
+        }
+        val localPlayerRepository = WearLocalPlayerRepository(
+            application,
+            localSongDao,
+            mockk<WearPlaybackStatePersistence>(),
+            performanceSettingsRepository,
+        )
+        val playbackController = WearPlaybackController(application, stateRepository)
+
+        repository = WearTransferRepository(
+            application = application,
+            localSongDao = localSongDao,
+            localPlaylistDao = localPlaylistDao,
+            channelClient = channelClient,
+            messageClient = messageClient,
+            nodeClient = nodeClient,
+            localPlayerRepository = localPlayerRepository,
+            stateRepository = stateRepository,
+            playbackController = playbackController,
+        )
+    }
+
+    @Test
+    fun `first sync sets createdAt equal to updatedAt`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        val entitySlot = slot<LocalPlaylistEntity>()
+        coEvery { localPlaylistDao.upsertPlaylist(capture(entitySlot), any()) } just Runs
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("s1")),
+            sourceNodeId = "node-1",
+        )
+
+        assertThat(entitySlot.captured.createdAt).isEqualTo(entitySlot.captured.updatedAt)
+    }
+
+    @Test
+    fun `re-sync preserves original createdAt but bumps updatedAt`() = runTest {
+        val originalCreatedAt = 1_000L
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns LocalPlaylistEntity(
+            playlistId = "p1",
+            name = "Road trip",
+            createdAt = originalCreatedAt,
+            updatedAt = originalCreatedAt,
+        )
+        val entitySlot = slot<LocalPlaylistEntity>()
+        coEvery { localPlaylistDao.upsertPlaylist(capture(entitySlot), any()) } just Runs
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("s1", "s2")),
+            sourceNodeId = "node-1",
+        )
+
+        assertThat(entitySlot.captured.createdAt).isEqualTo(originalCreatedAt)
+        assertThat(entitySlot.captured.updatedAt).isGreaterThan(originalCreatedAt)
+    }
+
+    @Test
+    fun `re-sync with a different song set replaces membership, not merges it`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        val crossRefsSlot = slot<List<LocalPlaylistSongCrossRef>>()
+        coEvery { localPlaylistDao.upsertPlaylist(any(), capture(crossRefsSlot)) } just Runs
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("a", "b")),
+            sourceNodeId = "node-1",
+        )
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("c")),
+            sourceNodeId = "node-1",
+        )
+
+        // The repository always regenerates the full cross-ref list from the incoming sync's
+        // songIds alone — it never reads current membership back in — so the last call's payload
+        // is exactly the new set, with no trace of the songs from the first call.
+        assertThat(crossRefsSlot.captured).containsExactly(
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "c", position = 0),
+        )
+    }
+
+    @Test
+    fun `cross-refs preserve songId order and position from the sync payload`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        val crossRefsSlot = slot<List<LocalPlaylistSongCrossRef>>()
+        coEvery { localPlaylistDao.upsertPlaylist(any(), capture(crossRefsSlot)) } just Runs
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("s3", "s1", "s2")),
+            sourceNodeId = "node-1",
+        )
+
+        assertThat(crossRefsSlot.captured).containsExactly(
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s3", position = 0),
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s1", position = 1),
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s2", position = 2),
+        ).inOrder()
+    }
+
+    @Test
+    fun `empty song list still upserts an empty cross-ref list, not a no-op`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Empty playlist", songIds = emptyList()),
+            sourceNodeId = "node-1",
+        )
+
+        coVerify(exactly = 1) { localPlaylistDao.upsertPlaylist(any(), emptyList()) }
+    }
+
+    @Test
+    fun `entity carries the synced name and playlistId through`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        val entitySlot = slot<LocalPlaylistEntity>()
+        coEvery { localPlaylistDao.upsertPlaylist(capture(entitySlot), any()) } just Runs
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Summer mix", songIds = listOf("s1")),
+            sourceNodeId = "node-1",
+        )
+
+        assertThat(entitySlot.captured.playlistId).isEqualTo("p1")
+        assertThat(entitySlot.captured.name).isEqualTo("Summer mix")
+    }
+
+    @Test
+    fun `cross-refs carry the matching pending title from the sync, by index`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        val crossRefsSlot = slot<List<LocalPlaylistSongCrossRef>>()
+        coEvery { localPlaylistDao.upsertPlaylist(any(), capture(crossRefsSlot)) } just Runs
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(
+                playlistId = "p1",
+                name = "Road trip",
+                songIds = listOf("s1", "s2"),
+                songTitles = listOf("First song", "Second song"),
+            ),
+            sourceNodeId = "node-1",
+        )
+
+        assertThat(crossRefsSlot.captured).containsExactly(
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s1", position = 0, pendingTitle = "First song"),
+            LocalPlaylistSongCrossRef(playlistId = "p1", songId = "s2", position = 1, pendingTitle = "Second song"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `a sync from an older phone with no songTitles falls back to an empty pending title`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        val crossRefsSlot = slot<List<LocalPlaylistSongCrossRef>>()
+        coEvery { localPlaylistDao.upsertPlaylist(any(), capture(crossRefsSlot)) } just Runs
+
+        // songTitles omitted entirely — WearPlaylistSync.songTitles defaults to emptyList().
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("s1")),
+            sourceNodeId = "node-1",
+        )
+
+        assertThat(crossRefsSlot.captured.single().pendingTitle).isEmpty()
+    }
+
+    // --- Ack (playlist-sync reliability fix) ---
+
+    @Test
+    fun `a sync with a requestId acks back to the source node once applied`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        val pathSlot = slot<String>()
+        val bytesSlot = slot<ByteArray>()
+        every { messageClient.sendMessage("node-9", capture(pathSlot), capture(bytesSlot)) } returns
+            Tasks.forResult(0)
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("s1"), requestId = "req-1"),
+            sourceNodeId = "node-9",
+        )
+
+        assertThat(pathSlot.captured).isEqualTo(WearDataPaths.PLAYLIST_SYNC_ACK)
+        val ack = Json.decodeFromString<WearPlaylistSyncAck>(String(bytesSlot.captured, Charsets.UTF_8))
+        assertThat(ack.playlistId).isEqualTo("p1")
+        assertThat(ack.requestId).isEqualTo("req-1")
+    }
+
+    @Test
+    fun `a sync with no requestId (old phone build) sends no ack`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("s1")),
+            sourceNodeId = "node-9",
+        )
+
+        verify(exactly = 0) { messageClient.sendMessage(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a failure sending the ack does not propagate out of onPlaylistSyncReceived`() = runTest {
+        coEvery { localPlaylistDao.getPlaylistById("p1") } returns null
+        every { messageClient.sendMessage(any(), any(), any()) } returns
+            Tasks.forException(RuntimeException("no route to node"))
+
+        // Should not throw — a lost ack just means the phone times out and resends the sync.
+        repository.onPlaylistSyncReceived(
+            WearPlaylistSync(playlistId = "p1", name = "Road trip", songIds = listOf("s1"), requestId = "req-1"),
+            sourceNodeId = "node-9",
+        )
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryPlaylistSyncTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/data/WearTransferRepositoryPlaylistSyncTest.kt
@@ -71,6 +71,9 @@ class WearTransferRepositoryPlaylistSyncTest {
             every { showAlbumArt } returns MutableStateFlow(true)
             every { dynamicColorTheming } returns MutableStateFlow(true)
             every { playButtonAnimation } returns MutableStateFlow(true)
+            // Already resolved: these tests are about transfer/playlist behavior, not about the
+            // startup window where the toggles aren't known yet.
+            every { isResolved } returns MutableStateFlow(true)
         }
         val localPlayerRepository = WearLocalPlayerRepository(
             application,

--- a/wear/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/WearLocalPlaylistViewModelTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/WearLocalPlaylistViewModelTest.kt
@@ -1,0 +1,378 @@
+package com.theveloper.pixelplay.presentation.viewmodel
+
+import android.app.Application
+import app.cash.turbine.test
+import com.google.android.gms.wearable.ChannelClient
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.NodeClient
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.MainCoroutineExtension
+import com.theveloper.pixelplay.data.WearLocalPlayerRepository
+import com.theveloper.pixelplay.data.WearOutputTarget
+import com.theveloper.pixelplay.data.WearPerformanceSettingsRepository
+import com.theveloper.pixelplay.data.WearPlaybackController
+import com.theveloper.pixelplay.data.WearPlaybackStatePersistence
+import com.theveloper.pixelplay.data.WearStateRepository
+import com.theveloper.pixelplay.data.WearTransferRepository
+import com.theveloper.pixelplay.data.local.LocalPlaylistDao
+import com.theveloper.pixelplay.data.local.LocalPlaylistEntity
+import com.theveloper.pixelplay.data.local.LocalPlaylistSongCrossRef
+import com.theveloper.pixelplay.data.local.LocalSongDao
+import com.theveloper.pixelplay.data.local.LocalSongEntity
+import com.theveloper.pixelplay.shared.WearTransferProgress
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
+
+/**
+ * [WearLocalPlayerRepository], [WearStateRepository], [WearPlaybackController] and
+ * [WearTransferRepository] are all constructed for real, not mocked: they're final Kotlin
+ * classes, and MockK can only fake a final class through its inline-mocking Java agent — which
+ * hangs indefinitely under this sandbox (documented in `WearTransferRepositoryPlaylistSyncTest`
+ * and `PlaylistWatchTransferCoordinatorTest` in `:app`).
+ *
+ * That constrains what `playAll`/`playFrom` can assert: [WearLocalPlayerRepository.playLocalSongs]
+ * itself is not verifiable here (it launches a coroutine that tries to bind a real
+ * `MediaController` to `WearPlaybackService`, which fails fast — and silently — off-device with
+ * no Android runtime present). What *is* real production behavior, reachable without a device, is
+ * the guard clause in the ViewModel that decides whether to call it at all, and the
+ * `stateRepository.setOutputTarget(WATCH)` call right after it — both are asserted via
+ * [WearStateRepository.outputTarget], a real (not mocked) collaborator.
+ *
+ * Every `stateIn`-backed property here (`playlists`, `playlistDetails`, `playlistSongs`,
+ * `playlistIdsReceiving`) delivers its `stateIn` initial value as a first, synchronous event to
+ * any new collector — *before* the upstream's real current value has had a chance to run through
+ * `WhileSubscribed`'s forwarding coroutine. Tests that assert on the sequence of emissions, or
+ * that read `.value` right after establishing a subscription, account for that placeholder
+ * explicitly rather than assuming the first `awaitItem()` is already the "real" one.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WearLocalPlaylistViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainCoroutineExtension = MainCoroutineExtension()
+    }
+
+    private val application = mockk<Application>(relaxed = true)
+    private val localPlaylistDao = mockk<LocalPlaylistDao>()
+    private val localSongDao = mockk<LocalSongDao>()
+    private val channelClient = mockk<ChannelClient>()
+    private val messageClient = mockk<MessageClient>()
+    private val nodeClient = mockk<NodeClient>()
+
+    private val playlistsFlow = MutableStateFlow<List<LocalPlaylistEntity>>(emptyList())
+    private val allCrossRefsFlow = MutableStateFlow<List<LocalPlaylistSongCrossRef>>(emptyList())
+    private val playlistSongsFlowById = mutableMapOf<String, MutableStateFlow<List<LocalPlaylistSongCrossRef>>>()
+    private val allSongsFlow = MutableStateFlow<List<LocalSongEntity>>(emptyList())
+    private val tempFiles = mutableListOf<File>()
+
+    private lateinit var stateRepository: WearStateRepository
+    private lateinit var transferRepository: WearTransferRepository
+    private lateinit var viewModel: WearLocalPlaylistViewModel
+
+    @BeforeEach
+    fun setUp() {
+        every { localPlaylistDao.observePlaylists() } returns playlistsFlow
+        every { localPlaylistDao.observeAllPlaylistSongCrossRefs() } returns allCrossRefsFlow
+        every { localPlaylistDao.observePlaylistSongs(any()) } answers {
+            val playlistId = firstArg<String>()
+            playlistSongsFlowById.getOrPut(playlistId) { MutableStateFlow(emptyList()) }
+        }
+        every { localSongDao.getAllSongs() } returns allSongsFlow
+        // WearTransferRepository's own init block treats any LocalSongEntity whose localPath
+        // doesn't resolve to a real, non-empty file as stale and deletes it — irrelevant to what
+        // this ViewModel does, but its background collector still runs and would call this on
+        // every song() fixture below if we didn't back them with real files (we do, see song()).
+        coEvery { localSongDao.deleteById(any()) } just Runs
+
+        stateRepository = WearStateRepository()
+        val performanceSettingsRepository = mockk<WearPerformanceSettingsRepository> {
+            every { showAlbumArt } returns MutableStateFlow(true)
+            every { dynamicColorTheming } returns MutableStateFlow(true)
+            every { playButtonAnimation } returns MutableStateFlow(true)
+        }
+        val localPlayerRepository = WearLocalPlayerRepository(
+            application,
+            localSongDao,
+            mockk<WearPlaybackStatePersistence>(),
+            performanceSettingsRepository,
+        )
+        val playbackController = WearPlaybackController(application, stateRepository)
+        transferRepository = WearTransferRepository(
+            application = application,
+            localSongDao = localSongDao,
+            localPlaylistDao = localPlaylistDao,
+            channelClient = channelClient,
+            messageClient = messageClient,
+            nodeClient = nodeClient,
+            localPlayerRepository = localPlayerRepository,
+            stateRepository = stateRepository,
+            playbackController = playbackController,
+        )
+
+        viewModel = WearLocalPlaylistViewModel(
+            localPlaylistDao = localPlaylistDao,
+            localSongDao = localSongDao,
+            localPlayerRepository = localPlayerRepository,
+            stateRepository = stateRepository,
+            transferRepository = transferRepository,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tempFiles.forEach { it.delete() }
+        tempFiles.clear()
+    }
+
+    /** Backed by a real, non-empty file so `hasPlayableLocalFile()`-style checks see it as valid. */
+    private fun song(id: String): LocalSongEntity {
+        val file = File.createTempFile("local-song-$id", ".m4a").apply {
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+            deleteOnExit()
+        }
+        tempFiles += file
+        return LocalSongEntity(
+            songId = id,
+            title = "Title $id",
+            artist = "Artist",
+            album = "Album",
+            albumId = 1L,
+            duration = 180_000L,
+            mimeType = "audio/mp4",
+            fileSize = file.length(),
+            bitrate = 128_000,
+            sampleRate = 44_100,
+            localPath = file.absolutePath,
+            transferredAt = 0L,
+        )
+    }
+
+    private fun crossRef(playlistId: String, songId: String, position: Int, pendingTitle: String = "") =
+        LocalPlaylistSongCrossRef(
+            playlistId = playlistId,
+            songId = songId,
+            position = position,
+            pendingTitle = pendingTitle,
+        )
+
+    /** Subscribes long enough for `WhileSubscribed`'s forwarding coroutine to run and update
+     *  `.value` past the `stateIn` placeholder, then lets go — `.value` keeps the real result. */
+    private suspend fun warmUp(flow: kotlinx.coroutines.flow.StateFlow<*>) {
+        flow.test {
+            awaitItem() // stateIn's initial placeholder
+            awaitItem() // the real, upstream-derived value
+        }
+    }
+
+    /**
+     * `playAll`/`playFrom` call into [WearLocalPlayerRepository.playLocalSongs], which
+     * fire-and-forgets a coroutine on `Dispatchers.Main` that ends up calling
+     * `android.net.Uri.fromFile` — unstubbed on a bare JVM, so it NPEs. That NPE is a pure artifact
+     * of running off-device (see the class doc) and unrelated to what these two tests actually
+     * assert — but `runTest` re-resolves `Dispatchers.Main` at cleanup and drains whatever is
+     * queued on it before returning, so the NPE always surfaces by the time `runTest` itself
+     * returns, *after* the test body (and its assertions) already ran to completion. Rather than
+     * fight `runTest`'s cleanup — every attempt to reroute `Dispatchers.Main` away from it still
+     * gets drained, since the lookup happens fresh at cleanup time, not once at start — this names
+     * the crash explicitly instead of letting it surface as an unexplained failure.
+     */
+    private fun expectFireAndForgetPlaybackCrash(body: suspend TestScope.() -> Unit) {
+        val error = assertThrows<NullPointerException> { runTest { body() } }
+        assertThat(error.message).contains("fromFile")
+    }
+
+    @Test
+    fun `playlists mirrors the DAO's observePlaylists flow`() = runTest {
+        viewModel.playlists.test {
+            assertThat(awaitItem()).isEmpty()
+            playlistsFlow.value = listOf(LocalPlaylistEntity("p1", "Road trip", 0L, 0L))
+            assertThat(awaitItem()).containsExactly(LocalPlaylistEntity("p1", "Road trip", 0L, 0L))
+        }
+    }
+
+    @Test
+    fun `playlistDetails resolves the entity matching the loaded playlistId`() = runTest {
+        playlistsFlow.value = listOf(
+            LocalPlaylistEntity("p1", "Road trip", 0L, 0L),
+            LocalPlaylistEntity("p2", "Gym", 0L, 0L),
+        )
+
+        viewModel.playlistDetails.test {
+            assertThat(awaitItem()).isNull()
+            viewModel.loadPlaylist("p2")
+            assertThat(awaitItem()?.playlistId).isEqualTo("p2")
+        }
+    }
+
+    @Test
+    fun `playlistSongs marks songs without a matching local file as unavailable, in sync order`() = runTest {
+        playlistSongsFlowById["p1"] = MutableStateFlow(
+            listOf(crossRef("p1", "s1", 0), crossRef("p1", "s2", 1), crossRef("p1", "s3", 2))
+        )
+        allSongsFlow.value = listOf(song("s1"), song("s3")) // s2 hasn't arrived yet
+
+        viewModel.loadPlaylist("p1")
+        viewModel.playlistSongs.test {
+            awaitItem() // stateIn's initial placeholder (emptyList)
+            val items = awaitItem()
+            assertThat(items.map { it.songId }).containsExactly("s1", "s2", "s3").inOrder()
+            assertThat(items.first { it.songId == "s1" }.isAvailable).isTrue()
+            assertThat(items.first { it.songId == "s2" }.isAvailable).isFalse()
+            assertThat(items.first { it.songId == "s3" }.isAvailable).isTrue()
+        }
+    }
+
+    @Test
+    fun `displayTitle prefers the real title, then the phone's pending title, then the raw id`() = runTest {
+        playlistSongsFlowById["p1"] = MutableStateFlow(
+            listOf(
+                crossRef("p1", "s1", 0, pendingTitle = "Ignored once available"),
+                crossRef("p1", "s2", 1, pendingTitle = "Still transferring"),
+                crossRef("p1", "s3", 2), // no pendingTitle — an older phone's sync
+            )
+        )
+        allSongsFlow.value = listOf(song("s1")) // only s1 has actually arrived
+
+        viewModel.loadPlaylist("p1")
+        viewModel.playlistSongs.test {
+            awaitItem() // stateIn's initial placeholder (emptyList)
+            val items = awaitItem()
+            assertThat(items.first { it.songId == "s1" }.displayTitle).isEqualTo("Title s1")
+            assertThat(items.first { it.songId == "s2" }.displayTitle).isEqualTo("Still transferring")
+            assertThat(items.first { it.songId == "s3" }.displayTitle).isEqualTo("s3")
+        }
+    }
+
+    @Test
+    fun `a song flips from pending to available as soon as it lands, without reloading`() = runTest {
+        playlistSongsFlowById["p1"] = MutableStateFlow(listOf(crossRef("p1", "s1", 0)))
+        viewModel.loadPlaylist("p1")
+
+        viewModel.playlistSongs.test {
+            awaitItem() // stateIn's initial placeholder (emptyList)
+            assertThat(awaitItem().single().isAvailable).isFalse()
+            allSongsFlow.value = listOf(song("s1"))
+            assertThat(awaitItem().single().isAvailable).isTrue()
+        }
+    }
+
+    @Test
+    fun `playlistIdsReceiving reports playlists with an actively transferring member`() = runTest {
+        allCrossRefsFlow.value = listOf(crossRef("p1", "s1", 0), crossRef("p2", "s2", 0))
+
+        viewModel.playlistIdsReceiving.test {
+            // Unlike playlistSongs, the placeholder (emptySet) and the real first combined value
+            // (also emptySet, since there's no active transfer yet) are structurally equal —
+            // StateFlow dedups them into a single emission, so there's only one item to await here.
+            assertThat(awaitItem()).isEmpty()
+            transferRepository.onProgressReceived(
+                WearTransferProgress(
+                    requestId = "r1",
+                    songId = "s1",
+                    bytesTransferred = 10L,
+                    totalBytes = 100L,
+                    status = WearTransferProgress.STATUS_TRANSFERRING,
+                )
+            )
+            assertThat(awaitItem()).containsExactly("p1")
+        }
+    }
+
+    @Test
+    fun `a failed transfer no longer counts as receiving once it reaches a terminal state`() = runTest {
+        allCrossRefsFlow.value = listOf(crossRef("p1", "s1", 0))
+
+        viewModel.playlistIdsReceiving.test {
+            assertThat(awaitItem()).isEmpty() // deduped placeholder, see the test above
+            transferRepository.onProgressReceived(
+                WearTransferProgress(
+                    requestId = "r1",
+                    songId = "s1",
+                    bytesTransferred = 10L,
+                    totalBytes = 100L,
+                    status = WearTransferProgress.STATUS_TRANSFERRING,
+                )
+            )
+            assertThat(awaitItem()).containsExactly("p1")
+
+            // The transfer fails — WearTransferRepository deliberately keeps this entry in
+            // activeTransfers (DownloadsScreen lists failed transfers under "Transfer issues"),
+            // it doesn't remove it. playlistIdsReceiving must stop counting it anyway: mere
+            // presence in the map isn't "still receiving" once the status is terminal.
+            transferRepository.onProgressReceived(
+                WearTransferProgress(
+                    requestId = "r1",
+                    songId = "s1",
+                    bytesTransferred = 10L,
+                    totalBytes = 100L,
+                    status = WearTransferProgress.STATUS_FAILED,
+                    error = "Transfer timed out",
+                )
+            )
+            assertThat(awaitItem()).isEmpty()
+        }
+    }
+
+    @Test
+    fun `playAll switches output to watch when at least one song is available`() = expectFireAndForgetPlaybackCrash {
+        playlistSongsFlowById["p1"] = MutableStateFlow(listOf(crossRef("p1", "s1", 0)))
+        allSongsFlow.value = listOf(song("s1"))
+        viewModel.loadPlaylist("p1")
+        warmUp(viewModel.playlistSongs)
+
+        assertThat(stateRepository.outputTarget.value).isEqualTo(WearOutputTarget.PHONE)
+        viewModel.playAll()
+        assertThat(stateRepository.outputTarget.value).isEqualTo(WearOutputTarget.WATCH)
+    }
+
+    @Test
+    fun `playAll is a no-op when every song is still pending transfer`() = runTest {
+        playlistSongsFlowById["p1"] = MutableStateFlow(listOf(crossRef("p1", "s1", 0)))
+        viewModel.loadPlaylist("p1")
+        warmUp(viewModel.playlistSongs) // s1 has no matching LocalSongEntity: pending
+
+        viewModel.playAll()
+        assertThat(stateRepository.outputTarget.value).isEqualTo(WearOutputTarget.PHONE)
+    }
+
+    @Test
+    fun `playFrom is a no-op when the requested song is still pending transfer`() = runTest {
+        playlistSongsFlowById["p1"] = MutableStateFlow(
+            listOf(crossRef("p1", "s1", 0), crossRef("p1", "s2", 1))
+        )
+        allSongsFlow.value = listOf(song("s1")) // s2 is pending
+        viewModel.loadPlaylist("p1")
+        warmUp(viewModel.playlistSongs)
+
+        viewModel.playFrom("s2")
+        assertThat(stateRepository.outputTarget.value).isEqualTo(WearOutputTarget.PHONE)
+    }
+
+    @Test
+    fun `playFrom an available song switches output to watch`() = expectFireAndForgetPlaybackCrash {
+        playlistSongsFlowById["p1"] = MutableStateFlow(
+            listOf(crossRef("p1", "s1", 0), crossRef("p1", "s2", 1))
+        )
+        allSongsFlow.value = listOf(song("s1"), song("s2"))
+        viewModel.loadPlaylist("p1")
+        warmUp(viewModel.playlistSongs)
+
+        viewModel.playFrom("s2")
+        assertThat(stateRepository.outputTarget.value).isEqualTo(WearOutputTarget.WATCH)
+    }
+}

--- a/wear/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/WearLocalPlaylistViewModelTest.kt
+++ b/wear/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/WearLocalPlaylistViewModelTest.kt
@@ -104,6 +104,9 @@ class WearLocalPlaylistViewModelTest {
             every { showAlbumArt } returns MutableStateFlow(true)
             every { dynamicColorTheming } returns MutableStateFlow(true)
             every { playButtonAnimation } returns MutableStateFlow(true)
+            // Already resolved: these tests are about transfer/playlist behavior, not about the
+            // startup window where the toggles aren't known yet.
+            every { isResolved } returns MutableStateFlow(true)
         }
         val localPlayerRepository = WearLocalPlayerRepository(
             application,


### PR DESCRIPTION
## Summary

Adds a full Wear OS companion experience to PixelPlay: transfer playlists from the phone to the watch for fully offline listening, play them locally on the watch with no phone nearby, and control phone playback remotely when the watch is in range — plus several rounds of reliability and performance hardening driven entirely by physical-device testing.

This PR is a squashed extraction of ~55 commits (13 PRs) built incrementally on a personal fork. It's isolated onto current `master` as a single self-contained changeset for review, with everything from that fork unrelated to this feature (an unrelated search-filter feature, an unrelated FTS fix, personal app branding) deliberately excluded — none of it is touched by this diff.

I'm aware there are several other Wear-OS-related branches already open in this repo. I haven't cross-checked this work against them in detail — happy to coordinate, rebase, or split this into smaller PRs if it overlaps with anything already in flight.

## Motivation

A phone-tethered watch companion is the easy 80%; the harder, more useful case is a watch that keeps working when the phone is left behind — running, gym, commuting without a pocket. That's the scenario this feature targets: transfer once over Bluetooth while both devices are together, then play back entirely offline on watch hardware that's meaningfully more constrained than even a budget phone (RAM, CPU, battery, a single shared Bluetooth radio).

## What's included

### 1. Playlist transfer: phone → watch
- Shared contract (`:shared` module) for playlist sync and per-song transfer metadata/progress, versioned so older/newer builds on either side degrade gracefully instead of crashing on an unknown field.
- Room schema on the watch for locally-stored playlists (membership + order), independent of song-download state — a playlist's structure arrives and is browsable before all of its audio has finished transferring.
- Phone-side transcoding: lossless or high-bitrate sources are re-encoded to AAC-LC 128 kbps before sending; sources already lossy at a reasonable bitrate are sent as-is (re-encoding an already-small MP3 only costs CPU and quality, no transfer-time benefit).
- A batch coordinator that syncs playlist structure first, then transcodes and streams pending songs one at a time — deliberately serial, never parallel, since the watch has a single Bluetooth radio to share with whatever else is using it (e.g. connected headphones).
- Phone UI: "Send to Watch" / "Update on Watch" action with a size/time estimate, a non-blocking progress banner/notification, and a library-wide badge so a batch transfer doesn't get lost behind app navigation.
- Watch UI: playlists received from the phone, songs not yet transferred shown disabled with a "waiting" state that flips live as songs arrive — no manual refresh needed.
- Batch-transfer intent (not full progress — that's cheap to rebuild) is persisted so a transfer interrupted by the phone process dyutomatically on next launch insteadof silently disappearing.
                                                                                             ### 2. Reliability hardening (multi a real failure seen on hardware)
- **Every fire-and-forget message in the pipeline now has an ack-and-retry**: playlist-sync messages, transfer-metadata messages, and final transfer outcome are all confirmed by the receiving side rather than assumed by the sender. This closes three real bugs found in testinsecond playlist's songs arriving bulaylist (sync message silentlydropped), a song completing on the watch but the phone never re-enabling retry for it (phone assumed success as soon as it finishannel, not when the watch confirmedthe save), and a duplicate-transfer rejection from the watch being silently dropped by the phone (the receiving message path existed in both manifests but had no handler on the phone side).
- **Transfer watchdog fix**: a stalled transfer's timeout used to only update in-memory state,
leaving the coroutine still blocked — so a "timed out" transfer couldstill finish successfully afterward and corrupt bookkeeping (`Transfer metadata missing` for data that had, in fact, fully arrived). The watchdog now closes the real input stream on timeout, routing the failure through the same single cleanup path the read loop already uses.
- **Failed-song retry**: songs that: Bluetooth radio contention withconnected headphones) are now retried once with a short backoff before being given up on.
- Both send-side (phone won't let y while any batch transfer is active)
and receive-side (watch-reported ouf truth for "is this song really on
the watch") race conditions are add

### 3. Local playback performance ()
- **Extractor scoped to MP4/AAC-LC only** (the only container this pipeline ever produces): the default extractor factory probes ~15 container formats on first use, each costing 120-300ms on watch-class hardware — visible as dropped frames right at playback start.
- **`LoadControl` buffer profile siring the phone's existing low-RAMbuffer-sizing logic, amplified for a device with meaningfully less memory that's often shared with another running app.
- **Audio offload with a runtime fallback**: requests offloaded audio playback (screen-off/AOD
play was measurably smoother than scontention between audio decode andCompose recomposition on the same core) — and, because ExoPlayer doesn't handle a HAL that accepts offload and then resets/stalls shortly after, replicates the same runtime detect-and-fallback approach already used on the phone side.
- **Mid-song stall watchdog**: covel mode found in release-build testing
— the player reports `STATE_READY`/udio has silently stopped, with no
state-change event to react to. A p(checks for stalled position overconsecutive ticks) triggers the same player-rebuild recovery independent of cause.
- **Lifecycle-aware recomposition audit**: ~45 collection sites across 11 files switched from `collectAsState()` to `collectAsStateWithLifecycle()`, plus gating the position/lyrics-index tick
loops on watch interactivity — closng (and costing CPU/battery) evenwith the screen off or in ambient mode.
- **Playback-state persistence across process death**: queue, current index, and position are
persisted (on meaningful events plut every UI tick) and restored —
paused, not auto-playing — on next r memory pressure from another
running app can have its process re

### 4. User-facing controls
- A "Watch" settings section on the phone with three toggles (album art, dynamic color theming,
play-button animation) that affect and are set from the phone but cached durably on the watch via a `DataItem` (survives the watch being disconnected at the moment of playback, which is the whole point). Backed by real measured costs: uncompressed artwork bitmaps up to ~16MB per song with no caching, full-bitmap re-sampling for theming on the main thread, and continuous per-frame path reconstruction for the play-button animation.
- All watch-related UI on the phone (send-to-watch actions, watch settings section) is hidden
entirely for a phone that has neverrather than only hiding whentemporarily disconnected — the previously-existing "paired but disconnected" state was already handled correctly.

## Key design decisions

- **`ChannelClient` for audio, `Meser protocol, `DataItem` for durable
settings/pairing state** — deliberafor different guarantee needs.`MessageClient` only confirms local delivery, not that the other side received it, so every place
it's used for something that must ns an explicit application-level ack.
- **Serial transfer, no queue yet**: multiple playlists transferring at once is explicitly out of scope for this PR — the phone currently blocks starting a second batch transfer while one is active, rather than queuing it. A real queue is a larger, separable piece of work.
- **Transcoding threshold**: re-enchelps (lossless/high-bitratesources), leave already-reasonable lossy sources alone.
- **Offload/stall recovery duplicatth the phone's equivalentplayer-engine code: the two players differ enough in shape (single-player watch service vs. dual-player crossfading phone engine) that sharing would mean threading watch-only parameters through phone-only code for a ~30-line function.

## Testing

- Extensive JVM unit test coverage  (shared contract, RoomDAOs/migrations that don't need instrumentation, transcoding decision logic, batch coordinator, performance-settings repository, offload/stall watchdogs, playback-state persistence, playlist-sync ack, transfer-outcome ack). Where a path genuinely can't be exercised without a real
device (`ChannelClient` streaming,  hardware,`MediaController`/foreground-service wiring, resource-shrinker behavior, static GMS client mocking that hangs this environment's sandbox), that's called out explicitly rather than left implicit or faked.
- All included commits build clean (`compileDebugKotlin` across `:app`/`:wear`/`:shared`) and pass their unit test suites; release builds (`assembleRelease` with R8 + resource shrinking) were verified clean, including a shrinker-specific bug this feature exposed (a capability-advertising resource reachable only by naming convention, not by any code reference, was being stripped from release builds).
- **Physical-device testing**: iterated over multiple real-hardware sessions across varied real-world conditions — screen on and off/ambient, watch worn on the wrist versus resting, charging and on battery, actively controlling music through the watch's own local playback as well as in remote-control mode with the phone in range, and a real ~30-minute outdoor run wearing the watch while a separate fitness-tracking app ran concurrently and competed for CPU/RAM/Bluetooth. Several of the reliability and performance fixes above exist specifically because that testing
surfaced real failures (lost songs, stalls, a watch that stoppedadvertising itself in release builds) that unit tests alone wouldn't have caught.

## Known gaps / explicitly out of scope

- `FAVORITES_SYNC_REQUEST`/`STATE` are declared in the shared contract but not fully wired (no manifest registration, no phone-side handler) — pre-existing from earlier in this feature's development, unrelated to what this PR delivers, left as-is rather than silently finishing
unrelated scope inside this PR.
- No real multi-playlist transfer queue yet — starting a second batch transfer is blocked, not
queued, while one is in progress.
- Reusing the batch-transfer maching. sending a whole album or artist)is a natural follow-up but isn't part of this PR.

## Checklist

- [x] `:app`, `:wear`, `:shared` compile clean
- [x] Unit test suites pass (no regests)
- [x] Release builds (`assembleRelease`, R8 + resource shrinking) verified clean
- [x] Tested on physical hardware aconditions (see Testing above)
- [ ] Open to feedback on splitting this into smaller reviewable PRs if preferred, given the size