### PR TITLE
refactor(connectivity): move ConnectivityStateHolder out of presentation/

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/connectivity/ConnectivityStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/connectivity/ConnectivityStateHolder.kt
@@ -1,4 +1,4 @@
-package com.theveloper.pixelplay.presentation.viewmodel
+package com.theveloper.pixelplay.data.connectivity
 
 import android.Manifest
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -221,7 +221,7 @@ class DualPlayerEngine @Inject constructor(
     private val jellyfinStreamProxy: com.theveloper.pixelplay.data.jellyfin.JellyfinStreamProxy,
     private val gdriveStreamProxy: com.theveloper.pixelplay.data.gdrive.GDriveStreamProxy,
     private val telegramCacheManager: com.theveloper.pixelplay.data.telegram.TelegramCacheManager,
-    private val connectivityStateHolder: com.theveloper.pixelplay.presentation.viewmodel.ConnectivityStateHolder
+    private val connectivityStateHolder: com.theveloper.pixelplay.data.connectivity.ConnectivityStateHolder
 ) {
     private companion object {
         private const val AUDIO_OFFLOAD_STALL_FALLBACK_MS = 4_000L

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -133,7 +133,7 @@ import androidx.core.content.ContextCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.mediarouter.media.MediaRouter
 import com.theveloper.pixelplay.presentation.screens.TabAnimation
-import com.theveloper.pixelplay.presentation.viewmodel.BluetoothAudioDeviceState
+import com.theveloper.pixelplay.data.connectivity.BluetoothAudioDeviceState
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 import org.drinkless.tdlib.TdApi
 import javax.inject.Inject
 
-import com.theveloper.pixelplay.presentation.viewmodel.ConnectivityStateHolder
+import com.theveloper.pixelplay.data.connectivity.ConnectivityStateHolder
 import com.theveloper.pixelplay.data.database.TelegramChannelEntity
 import com.theveloper.pixelplay.data.database.TelegramTopicEntity
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import com.theveloper.pixelplay.presentation.viewmodel.ConnectivityStateHolder
+import com.theveloper.pixelplay.data.connectivity.ConnectivityStateHolder
 
 @HiltViewModel
 class TelegramDashboardViewModel @Inject constructor(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/MediaControllerSyncStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/MediaControllerSyncStateHolder.kt
@@ -14,6 +14,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.EotStateHolder
+import com.theveloper.pixelplay.data.connectivity.ConnectivityStateHolder
 import com.theveloper.pixelplay.data.media.MediaMapper
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackDispatchStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackDispatchStateHolder.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.data.connectivity.ConnectivityStateHolder
 import com.theveloper.pixelplay.data.service.cast.CastRemotePlaybackState
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -8,6 +8,8 @@ import android.util.Log
 import kotlinx.coroutines.withContext
 import androidx.compose.animation.core.Animatable
 import androidx.core.content.ContextCompat
+import com.theveloper.pixelplay.data.connectivity.BluetoothAudioDeviceState
+import com.theveloper.pixelplay.data.connectivity.ConnectivityStateHolder
 import com.theveloper.pixelplay.data.model.LibraryTabId
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelTest.kt
@@ -2,6 +2,7 @@ package com.theveloper.pixelplay.presentation.viewmodel
 
 import android.content.Context
 import app.cash.turbine.test
+import com.theveloper.pixelplay.data.connectivity.ConnectivityStateHolder
 import com.theveloper.pixelplay.data.database.AlbumArtThemeDao
 import com.google.common.util.concurrent.ListenableFuture
 import com.theveloper.pixelplay.data.model.SearchFilterType


### PR DESCRIPTION
## What

`ConnectivityStateHolder` lives in `presentation/viewmodel/`, but
`data/service/player/DualPlayerEngine.kt` (data layer) already imports it from
there — a data → presentation dependency inversion that predates this change.
One of the small independent fixes listed in #2813.

## Change

Moves the file to `data/connectivity/`, a new single-file package (same shape
as the existing `data/paging/` and `data/provider/`). Package/import only —
zero behavior change.

**Moves, not splits.** The file also mixes Wi-Fi/network state with Bluetooth
state (591 lines, more than one reason to change), but separating those is a
refactor with its own design questions and doesn't belong in a preparatory
move. Noted as a possible follow-up, not done here.

9 files touched: the file itself, `DualPlayerEngine.kt`, and 7 more that
reference `ConnectivityStateHolder`/`BluetoothAudioDeviceState` — 3 of them
were in the same package and resolved it with no `import` at all, so they
gained one; the rest just had their import path updated.

## Known, accepted side effect

`app/src/release/generated/baselineProfiles/*.txt` still reference the old
`presentation.viewmodel.ConnectivityStateHolder` path. Those are ART profile
hints, not code — they simply stop matching for this class until the profile
is regenerated on-device, which needs a benchmark run and is out of scope for
this PR.

## Testing

No new tests: no logic changed, nothing new to assert. `:app:testDebugUnitTest`
— 388 tests, same 5 pre-existing failures as `master`'s baseline, none new.
`:app:assembleDebug` succeeds.