### PR TITLE
fix(tests): un-nest AudioMetaUtilsTest — the whole class never ran

### DIFF
--- a/app/src/test/java/com/theveloper/pixelplay/utils/AudioMetaUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/AudioMetaUtilsTest.kt
@@ -11,13 +11,14 @@ class AudioMetaUtilsTest {
         assertEquals("m4a", AudioMetaUtils.mimeTypeToFormat("audio/m4a"))
         assertEquals("m4a", AudioMetaUtils.mimeTypeToFormat("audio/x-m4a"))
         assertEquals("m4a", AudioMetaUtils.mimeTypeToFormat("audio/mp4a-latm"))
-        @Test
+    }
+
+    @Test
     fun mimeTypeToFormat_mapsUniversalFormats() {
         assertEquals("aiff", AudioMetaUtils.mimeTypeToFormat("audio/x-aiff"))
         assertEquals("ac3", AudioMetaUtils.mimeTypeToFormat("audio/ac3"))
         assertEquals("dts", AudioMetaUtils.mimeTypeToFormat("audio/vnd.dts"))
     }
-}
 
     @Test
     fun mimeTypeToFormat_mapsSamsungFormats() {
@@ -30,18 +31,5 @@ class AudioMetaUtilsTest {
         assertEquals("qcelp", AudioMetaUtils.mimeTypeToFormat("audio/x-qcelp"))
         assertEquals("ima", AudioMetaUtils.mimeTypeToFormat("audio/x-ima-adpcm"))
         assertEquals("ima", AudioMetaUtils.mimeTypeToFormat("audio/ima-adpcm"))
-        @Test
-    fun mimeTypeToFormat_mapsUniversalFormats() {
-        assertEquals("aiff", AudioMetaUtils.mimeTypeToFormat("audio/x-aiff"))
-        assertEquals("ac3", AudioMetaUtils.mimeTypeToFormat("audio/ac3"))
-        assertEquals("dts", AudioMetaUtils.mimeTypeToFormat("audio/vnd.dts"))
     }
 }
-    @Test
-    fun mimeTypeToFormat_mapsUniversalFormats() {
-        assertEquals("aiff", AudioMetaUtils.mimeTypeToFormat("audio/x-aiff"))
-        assertEquals("ac3", AudioMetaUtils.mimeTypeToFormat("audio/ac3"))
-        assertEquals("dts", AudioMetaUtils.mimeTypeToFormat("audio/vnd.dts"))
-    }
-}
-


### PR DESCRIPTION
## What

`app/src/test/.../utils/AudioMetaUtilsTest.kt` is corrupted by what looks like
a bad paste or merge: `mimeTypeToFormat_mapsUniversalFormats` is defined three
times — once at class level, and twice more as local functions nested inside
`mimeTypeToFormat_mapsM4aVariants` and `mimeTypeToFormat_mapsSamsungFormats`.
One of the small independent fixes listed in #2813.

Braces are balanced (Kotlin allows local functions), so it **compiles**. But a
local function carrying `@Test` compiles to a synthetic
`exterior$interior` method, and JUnit4's runner rejects the whole class for
it: `InvalidTestClassError: ... should not be static / should be public`.

**The real cost: the class never runs at all.** `mimeTypeToFormat()` — used on
every library scan — has had zero test coverage since this landed, silently.

## Change

Un-nests the three functions back to class level, three `@Test` methods, no
class-level duplication. **Not a single assertion changed** — I checked all 16
by hand against the current `mimeTypeToFormat()` implementation: they were
already correct, they just never ran. First real execution, all green.

## Testing

The fix *is* the test result: 3 tests that previously errored on
class-load now pass. `:app:testDebugUnitTest` — 390 tests, only the 4
*other* pre-existing baseline failures remain, none new.