### PR TITLE
fix(settings): self-describing item count in SettingsScreen

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
@@ -89,6 +89,25 @@ import com.theveloper.pixelplay.data.preferences.LaunchTab
 
 // SettingsTopBar removed, replaced by CollapsibleCommonTopBar
 
+/**
+ * The three fixed items rendered after the [SettingsCategory] loop in [SettingsScreen]: they
+ * aren't part of the loop (Accounts isn't a category at all; Device Capabilities and About are
+ * categories but excluded from the loop to render in a fixed trailing position instead).
+ *
+ * This enum is the single source of truth for "which items are trailing" — both the item count
+ * used to size the rounded-corner list (previously a literal `+ 3`, disconnected from the code
+ * that actually rendered those three items) and the filter that excludes [DEVICE_CAPABILITIES]
+ * and [ABOUT] from the main loop (previously a second, independent list of the same two
+ * categories, spelled out again). Adding a fourth trailing item now means adding one entry here;
+ * the compiler forces a matching branch in the `when` that renders it, and the loop's filter picks
+ * it up automatically if it wraps a [SettingsCategory] — no second place to remember to update.
+ */
+private enum class TrailingSettingsItem(val category: SettingsCategory?) {
+    DEVICE_CAPABILITIES(SettingsCategory.DEVICE_CAPABILITIES),
+    ACCOUNTS(category = null),
+    ABOUT(SettingsCategory.ABOUT),
+}
+
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -213,12 +232,11 @@ fun SettingsScreen(
             item {
                 val isDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
                 ExpressiveSettingsGroup {
-                    val mainCategories = SettingsCategory.entries.filter {
-                        it != SettingsCategory.ABOUT && 
-                        it != SettingsCategory.DEVICE_CAPABILITIES
-                    }
+                    val trailingItems = TrailingSettingsItem.entries
+                    val trailingCategories = trailingItems.mapNotNull { it.category }.toSet()
+                    val mainCategories = SettingsCategory.entries.filter { it !in trailingCategories }
 
-                    val totalItems = mainCategories.size + 3 // Device + Accounts + About
+                    val totalItems = mainCategories.size + trailingItems.size
                     fun shapeFor(index: Int) =
                         when {
                             totalItems == 1 -> RoundedCornerShape(24.dp)
@@ -250,36 +268,36 @@ fun SettingsScreen(
                         itemIndex++
                     }
 
-                    ExpressiveCategoryItem(
-                        category = SettingsCategory.DEVICE_CAPABILITIES,
-                        customColors = getCategoryColors(SettingsCategory.DEVICE_CAPABILITIES, isDark),
-                        onClick = { navController.navigateSafely(Screen.DeviceCapabilities.route) },
-                        shape = shapeFor(itemIndex)
-                    )
-                    if (itemIndex < totalItems - 1) {
-                        Spacer(modifier = Modifier.height(2.dp))
-                    }
-                    itemIndex++
+                    trailingItems.forEach { trailing ->
+                        when (trailing) {
+                            TrailingSettingsItem.DEVICE_CAPABILITIES -> ExpressiveCategoryItem(
+                                category = SettingsCategory.DEVICE_CAPABILITIES,
+                                customColors = getCategoryColors(SettingsCategory.DEVICE_CAPABILITIES, isDark),
+                                onClick = { navController.navigateSafely(Screen.DeviceCapabilities.route) },
+                                shape = shapeFor(itemIndex)
+                            )
 
-                    ExpressiveNavigationItem(
-                        title = stringResource(R.string.settings_category_accounts_title),
-                        subtitle = stringResource(R.string.settings_category_accounts_subtitle),
-                        icon = Icons.Rounded.AccountCircle,
-                        colors = getAccountsColors(isDark),
-                        onClick = { navController.navigateSafely(Screen.Accounts.route) },
-                        shape = shapeFor(itemIndex)
-                    )
-                    if (itemIndex < totalItems - 1) {
-                        Spacer(modifier = Modifier.height(2.dp))
-                    }
-                    itemIndex++
+                            TrailingSettingsItem.ACCOUNTS -> ExpressiveNavigationItem(
+                                title = stringResource(R.string.settings_category_accounts_title),
+                                subtitle = stringResource(R.string.settings_category_accounts_subtitle),
+                                icon = Icons.Rounded.AccountCircle,
+                                colors = getAccountsColors(isDark),
+                                onClick = { navController.navigateSafely(Screen.Accounts.route) },
+                                shape = shapeFor(itemIndex)
+                            )
 
-                    ExpressiveCategoryItem(
-                        category = SettingsCategory.ABOUT,
-                        customColors = getCategoryColors(SettingsCategory.ABOUT, isDark),
-                        onClick = { navController.navigateSafely("about") },
-                        shape = shapeFor(itemIndex)
-                    )
+                            TrailingSettingsItem.ABOUT -> ExpressiveCategoryItem(
+                                category = SettingsCategory.ABOUT,
+                                customColors = getCategoryColors(SettingsCategory.ABOUT, isDark),
+                                onClick = { navController.navigateSafely("about") },
+                                shape = shapeFor(itemIndex)
+                            )
+                        }
+                        if (itemIndex < totalItems - 1) {
+                            Spacer(modifier = Modifier.height(2.dp))
+                        }
+                        itemIndex++
+                    }
                 }
 
                 // for player active:


### PR DESCRIPTION
## What

`totalItems = mainCategories.size + 3` counts three trailing items (Device
Capabilities, Accounts, About) rendered by hand right after the category
loop, with a comment naming them — two sources of truth for the same fact.
Whoever adds a fourth trailing item and forgets the literal breaks the last
item's rounded corner. One of the small independent fixes listed in #2813.

**The original justification for this fix (as scoped) turned out to be
wrong, verified against the code**: adding a `SettingsCategory` does *not*
trigger the bug — `mainCategories.size` is already dynamic. The real
fragility is the literal `+ 3` itself, disconnected from the three
`ExpressiveXxxItem` calls it's supposed to count.

## Change

A private `TrailingSettingsItem` enum (`DEVICE_CAPABILITIES`, `ACCOUNTS`,
`ABOUT`) rendered via `forEach` + an exhaustive `when`, the same pattern
already used for `mainCategories`. `totalItems = mainCategories.size +
trailingItems.size` — a real collection's size, not a literal. Adding a
fourth item now needs a new enum entry, and the compiler refuses to build
until the `when` covers it — the bug class becomes impossible, not just
less likely.

A self-review pass (before this PR went up) found the first version of this
fix only half-solved the duplication: the loop's own exclusion filter
(`it != ABOUT && it != DEVICE_CAPABILITIES`) was a *second*, independent
list of the same two categories. Fixed by giving `TrailingSettingsItem` a
nullable `category: SettingsCategory?` (`null` for Accounts, which isn't a
category) and deriving the loop's filter from it — one enum now drives both
the count and the exclusion.

Zero behavior change: same `onClick`, same colors, same order, same
`shapeFor()`/`itemIndex` bookkeeping.

## Testing

No automated test added — `SettingsScreen` needs the full Hilt graph
(`NavController`, `PlayerViewModel` with ~30 dependencies, `SettingsViewModel`
via `hiltViewModel()`) to instantiate at all, and there's no existing Compose
test for this screen to build on; standing that up just for a
compiler-enforced, non-behavior-changing refactor felt disproportionate.

Attempted on-device visual verification instead; blocked by a sandbox
limitation in my own environment (synthetic input events never reached the
emulator — confirmed via raw `getevent` capture, unrelated to the app).
Verified instead: `assembleDebug` succeeds, full JVM baseline unaffected (5
pre-existing failures, none new), and the diff traced by hand against the
original for behavioral equivalence.