### PR TITLE
refactor: dedupe artist image menu, extract CollectionActionItem

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CollectionActionItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CollectionActionItem.kt
@@ -1,0 +1,66 @@
+package com.theveloper.pixelplay.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
+
+/**
+ * A single row in an actions list (rename, delete, export, ...) for a library collection
+ * (playlist, album, artist). `P.3`: extracted from `PlaylistDetailScreen`'s private
+ * `PlaylistActionItem` — the composable itself never depended on anything playlist-specific,
+ * and F4's collection detail screens (album, artist) reuse the same row.
+ */
+@Composable
+fun CollectionActionItem(
+    icon: Painter,
+    label: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = icon,
+                contentDescription = label,
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+        Spacer(modifier = Modifier.width(14.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -725,6 +725,50 @@ private fun ArtistAlbumSectionSongItem(
     }
 }
 
+/**
+ * The image-edit dropdown ("Change photo" / "Reset to default") shared by [SharedArtistTopBarProbe]
+ * and [CustomCollapsingTopBar] — two mutually exclusive top bar implementations picked by
+ * `UseSharedCollapsibleTopBarProbe`, each with its own trigger button and its own `showImageMenu`
+ * state, but until now with the menu's own content (labels, icons, the `hasCustomImage` branch)
+ * copy-pasted between them. `P.2`: one definition, both call sites.
+ */
+@Composable
+private fun ArtistImageEditMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    hasCustomImage: Boolean,
+    onChangeImage: () -> Unit,
+    onClearCustomImage: () -> Unit
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest
+    ) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.artist_action_change_photo)) },
+            leadingIcon = {
+                Icon(Icons.Rounded.AddAPhoto, contentDescription = null)
+            },
+            onClick = {
+                onDismissRequest()
+                onChangeImage()
+            }
+        )
+        if (hasCustomImage) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.artist_action_reset_to_default)) },
+                leadingIcon = {
+                    Icon(Icons.Rounded.Delete, contentDescription = null)
+                },
+                onClick = {
+                    onDismissRequest()
+                    onClearCustomImage()
+                }
+            )
+        }
+    }
+}
+
 @Composable
 private fun SharedArtistTopBarProbe(
     artist: Artist,
@@ -854,33 +898,13 @@ private fun SharedArtistTopBarProbe(
                         )
                     }
 
-                    DropdownMenu(
+                    ArtistImageEditMenu(
                         expanded = showImageMenu,
-                        onDismissRequest = { showImageMenu = false }
-                    ) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.artist_action_change_photo)) },
-                            leadingIcon = {
-                                Icon(Icons.Rounded.AddAPhoto, contentDescription = null)
-                            },
-                            onClick = {
-                                showImageMenu = false
-                                onChangeImage()
-                            }
-                        )
-                        if (hasCustomImage) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.artist_action_reset_to_default)) },
-                                leadingIcon = {
-                                    Icon(Icons.Rounded.Delete, contentDescription = null)
-                                },
-                                onClick = {
-                                    showImageMenu = false
-                                    onClearCustomImage()
-                                }
-                            )
-                        }
-                    }
+                        onDismissRequest = { showImageMenu = false },
+                        hasCustomImage = hasCustomImage,
+                        onChangeImage = onChangeImage,
+                        onClearCustomImage = onClearCustomImage
+                    )
                 }
             }
         )
@@ -1040,29 +1064,13 @@ private fun CustomCollapsingTopBar(
                         ) {
                             Icon(Icons.Rounded.Edit, contentDescription = stringResource(R.string.artist_cd_edit_image))
                         }
-                        DropdownMenu(
+                        ArtistImageEditMenu(
                             expanded = showImageMenu,
-                            onDismissRequest = { showImageMenu = false }
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.artist_action_change_photo)) },
-                                leadingIcon = { Icon(Icons.Rounded.AddAPhoto, contentDescription = null) },
-                                onClick = {
-                                    showImageMenu = false
-                                    onChangeImage()
-                                }
-                            )
-                            if (hasCustomImage) {
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.artist_action_reset_to_default)) },
-                                    leadingIcon = { Icon(Icons.Rounded.Delete, contentDescription = null) },
-                                    onClick = {
-                                        showImageMenu = false
-                                        onClearCustomImage()
-                                    }
-                                )
-                            }
-                        }
+                            onDismissRequest = { showImageMenu = false },
+                            hasCustomImage = hasCustomImage,
+                            onChangeImage = onChangeImage,
+                            onClearCustomImage = onClearCustomImage
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
@@ -94,7 +93,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -114,6 +112,7 @@ import androidx.navigation.NavController
 import coil.size.Size
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.presentation.components.CollectionActionItem
 import com.theveloper.pixelplay.presentation.components.MiniPlayerHeight
 import com.theveloper.pixelplay.presentation.components.PlaylistBottomSheet
 import com.theveloper.pixelplay.presentation.components.QueuePlaylistSongItem
@@ -852,7 +851,7 @@ fun PlaylistDetailScreen(
                         )
                     }
                 }
-                PlaylistActionItem(
+                CollectionActionItem(
                     icon = painterResource(R.drawable.rounded_edit_24),
                     label = editPlaylistLabel,
                     onClick = {
@@ -860,7 +859,7 @@ fun PlaylistDetailScreen(
                         showEditPlaylistDialog = true
                     }
                 )
-                PlaylistActionItem(
+                CollectionActionItem(
                     icon = painterResource(R.drawable.rounded_delete_24),
                     label = deletePlaylistLabel,
                     onClick = {
@@ -868,7 +867,7 @@ fun PlaylistDetailScreen(
                         showDeleteConfirmation = true
                     }
                 )
-                PlaylistActionItem(
+                CollectionActionItem(
                     icon = painterResource(R.drawable.outline_graph_1_24),
                     label = setDefaultTransitionLabel,
                     onClick = {
@@ -876,7 +875,7 @@ fun PlaylistDetailScreen(
                         navController.navigateSafely(Screen.EditTransition.createRoute(playlistId))
                     }
                 )
-                PlaylistActionItem(
+                CollectionActionItem(
                     icon = painterResource(R.drawable.rounded_attach_file_24),
                     label = exportPlaylistLabel,
                     onClick = {
@@ -1114,41 +1113,3 @@ fun PlaylistDetailScreen(
     }
 }
 
-
-@Composable
-private fun PlaylistActionItem(
-    icon: Painter,
-    label: String,
-    onClick: () -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp)
-            .clip(RoundedCornerShape(18.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                painter = icon,
-                contentDescription = label,
-                tint = MaterialTheme.colorScheme.primary
-            )
-        }
-        Spacer(modifier = Modifier.width(14.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-    }
-}


### PR DESCRIPTION
Two small independent cleanups from #2813's checklist, combined here since
both are cosmetic and unrelated in code area — two atomic commits, one PR.

## Commit 1 — dedupe the artist image-edit dropdown menu

`ArtistDetailScreen.kt` has two mutually exclusive top bar implementations
(`SharedArtistTopBarProbe` / `CustomCollapsingTopBar`, picked by
`UseSharedCollapsibleTopBarProbe`), each with its own trigger button and its
own `showImageMenu` state — but the `DropdownMenu` content itself (Change
photo / Reset to default: same strings, same icons, same `hasCustomImage`
branch) was copy-pasted between them.

**Not an overflow menu**, as an earlier draft of this fix assumed — it's the
image-edit menu; neither screen has an overflow menu at all.

Extracted the shared content into a private `ArtistImageEditMenu`, called
from both places. Each call site keeps its own trigger button and its own
`remember { mutableStateOf(false) }` — those genuinely differ
(`FilledIconButton` vs `SmallFloatingActionButton`, different position) and
aren't part of the duplication. Zero behavior change.

## Commit 2 — extract CollectionActionItem

`PlaylistActionItem` was `private` inside `PlaylistDetailScreen.kt`,
self-contained (icon, label, onClick — nothing playlist-specific), used only
in that file's options sheet. Moved to
`presentation/components/CollectionActionItem.kt` and renamed — it's a row
for any collection's action list, not just playlists.

This one is a real prerequisite, not just cleanup: the planned album/artist
collection-detail screens are expected to reuse this same row. Dropped two
imports (`Painter`, `clickable`) left orphaned in `PlaylistDetailScreen.kt`
once the only code using them moved out.

## Testing

No new tests — both are pure extract-method refactors, verified by hand
against the originals for behavioral equivalence (same items, same order,
same click handling, same layout). `assembleDebug` succeeds, full JVM
baseline unaffected (5 pre-existing failures, none new).