### PR TITLE
fix(github): point GitHub services at the renamed repo

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/github/GitHubAnnouncementPropertiesService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/github/GitHubAnnouncementPropertiesService.kt
@@ -36,8 +36,8 @@ class GitHubAnnouncementPropertiesService @Inject constructor() {
      * - play_store_link_pending_message
      */
     suspend fun fetchPlayStoreAnnouncement(
-        owner: String = "theovilardo",
-        repo: String = "PixelPlay",
+        owner: String = "PixelPlayerHQ",
+        repo: String = "PixelPlayer",
         branch: String = "master",
         configPath: String = "remote-config/app-announcements.properties",
     ): Result<PlayStoreAnnouncementRemoteConfig> {

--- a/app/src/main/java/com/theveloper/pixelplay/data/github/GitHubContributorService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/github/GitHubContributorService.kt
@@ -25,8 +25,8 @@ class GitHubContributorService @Inject constructor() {
      * Fetches contributors from the GitHub repository
      */
     suspend fun fetchContributors(
-        owner: String = "theovilardo",
-        repo: String = "PixelPlay"
+        owner: String = "PixelPlayerHQ",
+        repo: String = "PixelPlayer"
     ): Result<List<GitHubContributor>> {
         return withContext(Dispatchers.IO) {
             try {


### PR DESCRIPTION
## What

`GitHubAnnouncementPropertiesService.fetchPlayStoreAnnouncement()` defaulted
to `owner=theovilardo, repo=PixelPlay` — the project's name before the
rename to `PixelPlayerHQ/PixelPlayer`. One of the small independent fixes
listed in #2813.

It works today only because `raw.githubusercontent.com` still resolves the
old path (verified: both URLs return identical content, same etag) — a
silent dependency on nobody claiming the old name.

## Change

Points the defaults at the real repo. Single caller (`MainActivity.kt`) uses
no arguments, so that's the only thing that needed to change there.

A self-review pass (before this PR went up) found the identical problem in
the sibling `GitHubContributorService.fetchContributors()`, same
`owner`/`repo` defaults, powering the About screen's contributor list
(also called with no arguments) — not named in the original plan, but the
same bug. Confirmed empirically that this one is worse than the announcement
case: unlike the raw-content path, `api.github.com/repos/theovilardo/PixelPlay`
returns an actual HTTP 301, not a silent 200. Fixed with the same
one-line-per-default change.

## Testing

No test added in either file — this predates a separate, unmerged branch
that genericizes `GitHubAnnouncementPropertiesService` in a way that makes
it testable without hitting real network; redoing that refactor here would
duplicate that branch's own scope, and `GitHubContributorService` has no
equivalent seam at all. Nothing to assert about a default string value
without one.

`assembleDebug` succeeds, full JVM baseline unaffected (5 pre-existing
failures, none new).